### PR TITLE
Refactor api paths to use _id instead of name

### DIFF
--- a/components/form-fields/actions/ActionItems.tsx
+++ b/components/form-fields/actions/ActionItems.tsx
@@ -6,18 +6,17 @@ import UsageButton from './UsageButton'
 import { memo, JSX } from 'react'
 
 interface Props {
-  /** name of currently selected option */
+  id: string
   name: string
-  /** type of the option */
   type: 'exercise' | 'category' | 'modifier'
-  handleDelete?: (name: string) => void
-  handleDuplicate?: (name: string) => void
+  handleDelete?: (id: string) => void
+  handleDuplicate?: (id: string) => void
   deleteDisabled?: boolean
 }
-/** render all common action items  */
 export default memo(function ActionItems({
-  name,
   type,
+  id,
+  name,
   handleDelete,
   handleDuplicate,
   deleteDisabled,
@@ -30,7 +29,7 @@ export default memo(function ActionItems({
           description={`Create a new ${type} which is a duplicate of this ${type}.`}
           button={
             <Button
-              onClick={() => handleDuplicate(name)}
+              onClick={() => handleDuplicate(id)}
               startIcon={<ContentCopyIcon />}
             >
               Duplicate
@@ -51,7 +50,7 @@ export default memo(function ActionItems({
             <DeleteButton
               type={type}
               name={name}
-              handleDelete={() => handleDelete(name)}
+              handleDelete={() => handleDelete(id)}
               buttonProps={{ disabled: !!deleteDisabled }}
             />
           }

--- a/components/form-fields/actions/UsageButton.tsx
+++ b/components/form-fields/actions/UsageButton.tsx
@@ -20,7 +20,6 @@ import { stringifySetType } from '../../../lib/util'
 const maxRecords = 10
 
 interface Props {
-  /** name of the exercise */
   name: string
   buttonProps?: ButtonProps
 }

--- a/components/forms/CategoryForm.tsx
+++ b/components/forms/CategoryForm.tsx
@@ -31,12 +31,10 @@ export default function CategoryForm({
   )
 
   const handleDelete = useCallback(
-    async (name: string) => {
-      await deleteCategory(name)
+    async (id: string) => {
+      await deleteCategory(id)
       setUrlCategory(null)
-      mutateCategories((cur) =>
-        cur?.filter((category) => category.name !== name)
-      )
+      mutateCategories((cur) => cur?.filter((category) => category._id !== id))
     },
     [mutateCategories, setUrlCategory]
   )
@@ -55,6 +53,7 @@ export default function CategoryForm({
       </Grid>
       <Grid size={12}>
         <ActionItems
+          id={_id}
           name={name}
           type="category"
           handleDelete={handleDelete}

--- a/components/forms/ExerciseForm.tsx
+++ b/components/forms/ExerciseForm.tsx
@@ -50,19 +50,22 @@ export default function ExerciseForm({ exercise, handleUpdate }: Props) {
   // todo: validate (drop empty notes)
 
   const handleDelete = useCallback(
-    async (name: string) => {
-      await deleteExercise(name)
+    async (id: string) => {
+      await deleteExercise(id)
       setUrlExercise(null)
-      mutateExercises((cur) => cur?.filter((e) => e.name !== name))
+      mutateExercises((cur) => cur?.filter((e) => e._id !== id))
     },
     [mutateExercises, setUrlExercise]
   )
 
   const handleDuplicate = useCallback(
-    async (name: string) => {
-      const newName = name + ' (copy)'
+    async (id: string) => {
       mutateExercises(async (cur = []) => {
-        const exercise = cur.find((e) => e.name === name) ?? {}
+        const exercise = cur.find((e) => e._id === id)
+
+        if (!exercise) return cur
+
+        const newName = exercise.name + ' (copy)'
         const newExercise = createExercise(newName, exercise)
         await updateExercise(newExercise)
         setUrlExercise(newName)
@@ -143,6 +146,7 @@ export default function ExerciseForm({ exercise, handleUpdate }: Props) {
       </Grid>
       <Grid size={12}>
         <ActionItems
+          id={_id}
           name={name}
           type="exercise"
           handleDelete={handleDelete}

--- a/components/forms/ModifierForm.tsx
+++ b/components/forms/ModifierForm.tsx
@@ -32,12 +32,10 @@ export default function ModifierForm({
   )
 
   const handleDelete = useCallback(
-    async (name: string) => {
-      await deleteModifier(name)
+    async (id: string) => {
+      await deleteModifier(id)
       setUrlModifier(null)
-      mutateModifiers((cur) =>
-        cur?.filter((modifier) => modifier.name !== name)
-      )
+      mutateModifiers((cur) => cur?.filter((modifier) => modifier._id !== id))
     },
     [mutateModifiers, setUrlModifier]
   )
@@ -69,6 +67,7 @@ export default function ModifierForm({
       </Grid>
       <Grid size={12}>
         <ActionItems
+          id={_id}
           name={name}
           type="modifier"
           handleDelete={handleDelete}

--- a/lib/frontend/restService.ts
+++ b/lib/frontend/restService.ts
@@ -220,7 +220,7 @@ export function useExercise(id: string | null, config?: SWRConfiguration) {
 }
 
 export async function addExercise(newExercise: Exercise): Promise<Exercise> {
-  return fetchJson(URI_EXERCISES + newExercise.name, {
+  return fetchJson(URI_EXERCISES + newExercise._id, {
     method: 'POST',
     body: toJson(newExercise),
     headers: { 'content-type': 'application/json' },
@@ -228,7 +228,7 @@ export async function addExercise(newExercise: Exercise): Promise<Exercise> {
 }
 
 export async function updateExercise(newExercise: Exercise): Promise<Exercise> {
-  return fetchJson(URI_EXERCISES + newExercise.name, {
+  return fetchJson(URI_EXERCISES + newExercise._id, {
     method: 'PUT',
     body: toJson(newExercise),
     headers: { 'content-type': 'application/json' },
@@ -240,15 +240,15 @@ export async function updateExerciseFields(
   updates: Partial<Exercise>
 ): Promise<Exercise> {
   const id = exercise._id
-  return fetchJson(URI_EXERCISES + exercise.name, {
+  return fetchJson(URI_EXERCISES + exercise._id, {
     method: 'PATCH',
     body: toJson({ id, updates }),
     headers: { 'content-type': 'application/json' },
   })
 }
 
-export async function deleteExercise(name: string): Promise<string> {
-  return fetchJson(URI_EXERCISES + name, {
+export async function deleteExercise(id: string): Promise<string> {
+  return fetchJson(URI_EXERCISES + id, {
     method: 'DELETE',
     headers: { 'content-type': 'application/json' },
   })
@@ -272,28 +272,27 @@ export function useModifiers() {
 }
 
 export async function addModifier(newModifier: Modifier): Promise<Modifier> {
-  return fetchJson(URI_MODIFIERS + newModifier.name, {
+  return fetchJson(URI_MODIFIERS + newModifier._id, {
     method: 'POST',
     body: toJson(newModifier),
     headers: { 'content-type': 'application/json' },
   })
 }
 
-// todo: add a modifiers/id/<id> URI? Weird to use name in uri then send id to backend
 export async function updateModifierFields(
   modifier: Modifier,
   updates: Partial<Modifier>
 ): Promise<Modifier> {
   const id = modifier._id
-  return fetchJson(URI_MODIFIERS + modifier.name, {
+  return fetchJson(URI_MODIFIERS + modifier._id, {
     method: 'PATCH',
     body: toJson({ id, updates }),
     headers: { 'content-type': 'application/json' },
   })
 }
 
-export async function deleteModifier(name: string): Promise<string> {
-  return fetchJson(URI_MODIFIERS + name, {
+export async function deleteModifier(id: string): Promise<string> {
+  return fetchJson(URI_MODIFIERS + id, {
     method: 'DELETE',
     headers: { 'content-type': 'application/json' },
   })
@@ -316,28 +315,27 @@ export function useCategories() {
 }
 
 export async function addCategory(newCategory: Category): Promise<Category> {
-  return fetchJson(URI_CATEGORIES + newCategory.name, {
+  return fetchJson(URI_CATEGORIES + newCategory._id, {
     method: 'POST',
     body: toJson(newCategory),
     headers: { 'content-type': 'application/json' },
   })
 }
 
-// todo: add a categories/id/<id> URI? Weird to use name in uri then send id to backend
 export async function updateCategoryFields(
   category: Category,
   updates: Partial<Category>
 ): Promise<Category> {
   const id = category._id
-  return fetchJson(URI_CATEGORIES + category.name, {
+  return fetchJson(URI_CATEGORIES + category._id, {
     method: 'PATCH',
     body: toJson({ id, updates }),
     headers: { 'content-type': 'application/json' },
   })
 }
 
-export async function deleteCategory(name: string): Promise<string> {
-  return fetchJson(URI_CATEGORIES + name, {
+export async function deleteCategory(id: string): Promise<string> {
+  return fetchJson(URI_CATEGORIES + id, {
     method: 'DELETE',
     headers: { 'content-type': 'application/json' },
   })

--- a/lib/frontend/restService.ts
+++ b/lib/frontend/restService.ts
@@ -182,7 +182,7 @@ export async function updateRecordFields(
 ): Promise<Record> {
   return fetchJson(URI_RECORDS + id, {
     method: 'PATCH',
-    body: toJson({ id, updates }),
+    body: toJson(updates),
     headers: { 'content-type': 'application/json' },
   })
 }
@@ -239,10 +239,9 @@ export async function updateExerciseFields(
   exercise: Exercise,
   updates: Partial<Exercise>
 ): Promise<Exercise> {
-  const id = exercise._id
   return fetchJson(URI_EXERCISES + exercise._id, {
     method: 'PATCH',
-    body: toJson({ id, updates }),
+    body: toJson(updates),
     headers: { 'content-type': 'application/json' },
   })
 }
@@ -283,10 +282,9 @@ export async function updateModifierFields(
   modifier: Modifier,
   updates: Partial<Modifier>
 ): Promise<Modifier> {
-  const id = modifier._id
   return fetchJson(URI_MODIFIERS + modifier._id, {
     method: 'PATCH',
-    body: toJson({ id, updates }),
+    body: toJson(updates),
     headers: { 'content-type': 'application/json' },
   })
 }
@@ -326,10 +324,9 @@ export async function updateCategoryFields(
   category: Category,
   updates: Partial<Category>
 ): Promise<Category> {
-  const id = category._id
   return fetchJson(URI_CATEGORIES + category._id, {
     method: 'PATCH',
-    body: toJson({ id, updates }),
+    body: toJson(updates),
     headers: { 'content-type': 'application/json' },
   })
 }

--- a/pages/api/categories/[id].api.ts
+++ b/pages/api/categories/[id].api.ts
@@ -21,7 +21,7 @@ async function handler(req: NextApiRequest, userId: UserId) {
     case 'POST':
       return await addCategory(userId, req.body)
     case 'PATCH':
-      return await updateCategoryFields(userId, req.body)
+      return await updateCategoryFields(userId, id, req.body)
     case 'DELETE':
       return await deleteCategory(userId, id)
     default:

--- a/pages/api/categories/[id].api.ts
+++ b/pages/api/categories/[id].api.ts
@@ -4,26 +4,26 @@ import {
   UserId,
 } from '../../../lib/backend/apiMiddleware/util'
 import withStatusHandler from '../../../lib/backend/apiMiddleware/withStatusHandler'
-import { validateName } from '../../../lib/backend/apiQueryValidationService'
+import { validateId } from '../../../lib/backend/apiQueryValidationService'
 import {
-  addModifier,
-  deleteModifier,
-  fetchModifier,
-  updateModifierFields,
+  addCategory,
+  deleteCategory,
+  fetchCategory,
+  updateCategoryFields,
 } from '../../../lib/backend/mongoService'
 
 async function handler(req: NextApiRequest, userId: UserId) {
-  const name = validateName(req.query.name)
+  const id = validateId(req.query.id)
 
   switch (req.method) {
     case 'GET':
-      return await fetchModifier(userId, name)
+      return await fetchCategory(userId, id)
     case 'POST':
-      return await addModifier(userId, req.body)
+      return await addCategory(userId, req.body)
     case 'PATCH':
-      return await updateModifierFields(userId, req.body)
+      return await updateCategoryFields(userId, req.body)
     case 'DELETE':
-      return await deleteModifier(userId, name)
+      return await deleteCategory(userId, id)
     default:
       throw methodNotAllowed
   }

--- a/pages/api/categories/[id].test.ts
+++ b/pages/api/categories/[id].test.ts
@@ -10,10 +10,11 @@ import {
   expectApiRespondsWithData,
 } from '../../../lib/testUtils'
 import { createCategory } from '../../../models/AsyncSelectorOption/Category'
-import handler from './[name].api'
+import handler from './[id].api'
+import { generateId } from '../../../lib/util'
 
 const data = createCategory('hi')
-const params = { name: 'name' }
+const params = { id: generateId() }
 
 it('fetches given category', async () => {
   vi.mocked(fetchCategory).mockResolvedValue(data)

--- a/pages/api/exercises/[id].api.ts
+++ b/pages/api/exercises/[id].api.ts
@@ -4,26 +4,29 @@ import {
   UserId,
 } from '../../../lib/backend/apiMiddleware/util'
 import withStatusHandler from '../../../lib/backend/apiMiddleware/withStatusHandler'
-import { validateName } from '../../../lib/backend/apiQueryValidationService'
+import { validateId } from '../../../lib/backend/apiQueryValidationService'
 import {
-  addCategory,
-  deleteCategory,
-  fetchCategory,
-  updateCategoryFields,
+  addExercise,
+  deleteExercise,
+  fetchExercise,
+  updateExercise,
+  updateExerciseFields,
 } from '../../../lib/backend/mongoService'
 
 async function handler(req: NextApiRequest, userId: UserId) {
-  const name = validateName(req.query.name)
+  const id = validateId(req.query.id)
 
   switch (req.method) {
     case 'GET':
-      return await fetchCategory(userId, name)
+      return await fetchExercise(userId, id)
     case 'POST':
-      return await addCategory(userId, req.body)
+      return await addExercise(userId, req.body)
+    case 'PUT':
+      return await updateExercise(userId, req.body)
     case 'PATCH':
-      return await updateCategoryFields(userId, req.body)
+      return await updateExerciseFields(userId, req.body)
     case 'DELETE':
-      return await deleteCategory(userId, name)
+      return await deleteExercise(userId, id)
     default:
       throw methodNotAllowed
   }

--- a/pages/api/exercises/[id].api.ts
+++ b/pages/api/exercises/[id].api.ts
@@ -24,7 +24,7 @@ async function handler(req: NextApiRequest, userId: UserId) {
     case 'PUT':
       return await updateExercise(userId, req.body)
     case 'PATCH':
-      return await updateExerciseFields(userId, req.body)
+      return await updateExerciseFields(userId, id, req.body)
     case 'DELETE':
       return await deleteExercise(userId, id)
     default:

--- a/pages/api/exercises/[id].test.ts
+++ b/pages/api/exercises/[id].test.ts
@@ -10,11 +10,12 @@ import {
   expectApiErrorsOnMissingParams,
   expectApiRespondsWithData,
 } from '../../../lib/testUtils'
-import handler from './[name].api'
+import handler from './[id].api'
 import { createExercise } from '../../../models/AsyncSelectorOption/Exercise'
+import { generateId } from '../../../lib/util'
 
 const data = createExercise('hi')
-const params = { name: 'name' }
+const params = { id: generateId() }
 
 it('fetches given exercise', async () => {
   vi.mocked(fetchExercise).mockResolvedValue(data)

--- a/pages/api/modifiers/[id].api.ts
+++ b/pages/api/modifiers/[id].api.ts
@@ -21,7 +21,7 @@ async function handler(req: NextApiRequest, userId: UserId) {
     case 'POST':
       return await addModifier(userId, req.body)
     case 'PATCH':
-      return await updateModifierFields(userId, req.body)
+      return await updateModifierFields(userId, id, req.body)
     case 'DELETE':
       return await deleteModifier(userId, id)
     default:

--- a/pages/api/modifiers/[id].api.ts
+++ b/pages/api/modifiers/[id].api.ts
@@ -4,29 +4,26 @@ import {
   UserId,
 } from '../../../lib/backend/apiMiddleware/util'
 import withStatusHandler from '../../../lib/backend/apiMiddleware/withStatusHandler'
-import { validateName } from '../../../lib/backend/apiQueryValidationService'
+import { validateId } from '../../../lib/backend/apiQueryValidationService'
 import {
-  addExercise,
-  deleteExercise,
-  fetchExercise,
-  updateExercise,
-  updateExerciseFields,
+  addModifier,
+  deleteModifier,
+  fetchModifier,
+  updateModifierFields,
 } from '../../../lib/backend/mongoService'
 
 async function handler(req: NextApiRequest, userId: UserId) {
-  const name = validateName(req.query.name)
+  const id = validateId(req.query.id)
 
   switch (req.method) {
     case 'GET':
-      return await fetchExercise(userId, name)
+      return await fetchModifier(userId, id)
     case 'POST':
-      return await addExercise(userId, req.body)
-    case 'PUT':
-      return await updateExercise(userId, req.body)
+      return await addModifier(userId, req.body)
     case 'PATCH':
-      return await updateExerciseFields(userId, req.body)
+      return await updateModifierFields(userId, req.body)
     case 'DELETE':
-      return await deleteExercise(userId, name)
+      return await deleteModifier(userId, id)
     default:
       throw methodNotAllowed
   }

--- a/pages/api/modifiers/[id].test.ts
+++ b/pages/api/modifiers/[id].test.ts
@@ -9,11 +9,12 @@ import {
   expectApiErrorsOnMissingParams,
   expectApiRespondsWithData,
 } from '../../../lib/testUtils'
-import handler from './[name].api'
+import handler from './[id].api'
 import { createModifier } from '../../../models/AsyncSelectorOption/Modifier'
+import { generateId } from '../../../lib/util'
 
 const data = createModifier('hi', 5)
-const params = { name: 'name' }
+const params = { id: generateId() }
 
 it('fetches given modifier', async () => {
   vi.mocked(fetchModifier).mockResolvedValue(data)

--- a/pages/api/records/[id].api.ts
+++ b/pages/api/records/[id].api.ts
@@ -23,7 +23,7 @@ async function handler(req: NextApiRequest, userId: UserId) {
     case 'PUT':
       return await updateRecord(userId, req.body)
     case 'PATCH':
-      return await updateRecordFields(userId, req.body)
+      return await updateRecordFields(userId, id, req.body)
     default:
       throw methodNotAllowed
   }


### PR DESCRIPTION
Categories and Modifiers had been using `name` instead of `_id` in the rest api. This change brings the urls in line with the backend, which had been using the `_id` to search for records.

Also investigated using PUT instead of PATCH requests but determined it makes sense to stick with PATCH. Switching to PUT is not a big change because most usage already has access to the old record, but the forms are all structured where individual fields are updated on change so we'd have to switch from partial updates on the frontend to a full replacement on the backend at some point.

Note: many components are optimized to only rerender when their relevant field changes. Changing to PUT doesn't actually affect the optimization because the components already have access to the old record; it doesn't need to be passed via props, which would trigger a rerender since the object is updated on any change.