### PR TITLE
Create custom ApiError for errors returned from the api

### DIFF
--- a/lib/backend/apiMiddleware/util.ts
+++ b/lib/backend/apiMiddleware/util.ts
@@ -2,8 +2,8 @@ import { StatusCodes } from 'http-status-codes'
 import { ObjectId } from 'mongodb'
 import { GetServerSidePropsContext, NextApiRequest } from 'next'
 import { getServerSession } from 'next-auth'
-import { ApiError } from 'next/dist/server/api-utils'
 import { authOptions } from '../../../pages/api/auth/[...nextauth].api'
+import { ApiError } from '../../../models/ApiError'
 
 export type ApiHandler<T> = (
   req: NextApiRequest,

--- a/lib/backend/apiMiddleware/withStatusHandler.test.ts
+++ b/lib/backend/apiMiddleware/withStatusHandler.test.ts
@@ -1,7 +1,7 @@
 import { StatusCodes } from 'http-status-codes'
 import { testApiHandler } from 'next-test-api-route-handler'
-import { ApiError } from 'next/dist/server/api-utils'
 import { vi } from 'vitest'
+import { ApiError } from '../../../models/ApiError'
 import withStatusHandler from './withStatusHandler'
 
 const mockHandler = vi.fn()

--- a/lib/backend/apiMiddleware/withStatusHandler.ts
+++ b/lib/backend/apiMiddleware/withStatusHandler.ts
@@ -1,5 +1,6 @@
 import { StatusCodes } from 'http-status-codes'
 import { NextApiRequest, NextApiResponse } from 'next'
+import { ZodError } from 'zod'
 import { ApiError } from '../../../models/ApiError'
 import { ApiHandler, getUserId } from './util'
 
@@ -10,9 +11,6 @@ export default function withStatusHandler<T>(handler: ApiHandler<T>) {
   return async (req: NextApiRequest, res: NextApiResponse) => {
     try {
       const userId = await getUserId(req, res)
-      if (process.env.SERVER_LOG_LEVEL === 'verbose') {
-        console.log(`${req.method} ${req.url} for user ${userId.toString()}`)
-      }
 
       if (req.body && req.headers['content-type'] !== 'application/json') {
         throw new ApiError(StatusCodes.BAD_REQUEST, 'content type must be json')
@@ -20,26 +18,29 @@ export default function withStatusHandler<T>(handler: ApiHandler<T>) {
 
       const payload = await handler(req, userId)
 
-      // Note: null data is being returned as status 200. Originally it was returning
-      // a 404, but that made implementation more complicated handling the error,
-      // and a 200 makes sense because the request did complete successfully, it was just empty.
-      // A 204 (no content) might semantically make sense, but it breaks json parsing and
-      // the client has to then factor in a null body instead of an empty json object.
-      res.status(StatusCodes.OK).json(payload)
-    } catch (e) {
-      let statusCode = StatusCodes.INTERNAL_SERVER_ERROR
-      let message = 'An unexpected error occured.'
-      if (e instanceof ApiError) {
-        statusCode = e.statusCode
-        message = e.message
+      if (!payload) {
+        throw new ApiError(StatusCodes.NOT_FOUND, 'not found')
       }
 
-      if (process.env.SERVER_LOG_LEVEL === 'verbose') {
-        statusCode > 499
-          ? console.trace(e)
-          : console.error(`Error ${statusCode}: ${message}`)
+      res.status(StatusCodes.OK).json(payload)
+    } catch (e) {
+      if (e instanceof ApiError) {
+        const { statusCode, message } = e
+        res.status(statusCode).json({ statusCode, message })
+      } else if (e instanceof ZodError) {
+        const statusCode = StatusCodes.BAD_REQUEST
+        res.status(statusCode).json({
+          statusCode,
+          message: 'request body is malformed',
+          details: e.errors,
+        })
+      } else {
+        if (process.env.SERVER_LOG_LEVEL === 'verbose') {
+          console.error(e)
+        }
+        const statusCode = StatusCodes.INTERNAL_SERVER_ERROR
+        res.status(statusCode).json({ statusCode, message: 'unknown error' })
       }
-      res.status(statusCode).json(message)
     }
   }
 }

--- a/lib/backend/apiMiddleware/withStatusHandler.ts
+++ b/lib/backend/apiMiddleware/withStatusHandler.ts
@@ -1,6 +1,6 @@
 import { StatusCodes } from 'http-status-codes'
 import { NextApiRequest, NextApiResponse } from 'next'
-import { ApiError } from 'next/dist/server/api-utils'
+import { ApiError } from '../../../models/ApiError'
 import { ApiHandler, getUserId } from './util'
 
 /** This HOF is responsible for anything involving "res" in the handler.

--- a/lib/backend/apiQueryValidationService.test.ts
+++ b/lib/backend/apiQueryValidationService.test.ts
@@ -1,5 +1,4 @@
 import { ObjectId } from 'mongodb'
-import { ApiError } from 'next/dist/server/api-utils'
 import { v1 as invalidUuid } from 'uuid'
 import { generateId } from '../../lib/util'
 import BodyweightQuery from '../../models/query-filters/BodyweightQuery'
@@ -8,6 +7,8 @@ import { ExerciseQuery } from '../../models/query-filters/ExerciseQuery'
 import { MatchType } from '../../models/query-filters/MongoQuery'
 import { RecordQuery } from '../../models/query-filters/RecordQuery'
 import { Status } from '../../models/Status'
+import { devUserId } from '../frontend/constants'
+import { ApiError } from '../../models/ApiError'
 import {
   ApiReq,
   buildBodyweightQuery,
@@ -21,7 +22,6 @@ import {
   validateSort,
   validateStatus,
 } from './apiQueryValidationService'
-import { devUserId } from '../frontend/constants'
 
 describe('validation', () => {
   describe('validateId', () => {

--- a/lib/backend/apiQueryValidationService.ts
+++ b/lib/backend/apiQueryValidationService.ts
@@ -1,6 +1,5 @@
 import { StatusCodes } from 'http-status-codes'
 import { Filter, ObjectId } from 'mongodb'
-import { ApiError } from 'next/dist/server/api-utils'
 import { validDateStringRegex } from '../../lib/frontend/constants'
 import { isValidId } from '../../lib/util'
 import { Exercise } from '../../models/AsyncSelectorOption/Exercise'
@@ -18,6 +17,7 @@ import {
 import { RecordQuery } from '../../models/query-filters/RecordQuery'
 import { Record } from '../../models/Record'
 import { Status } from '../../models/Status'
+import { ApiError } from '../../models/ApiError'
 
 type ApiParam = string | string[] | undefined
 // only exported for the test file

--- a/lib/backend/mongoService.ts
+++ b/lib/backend/mongoService.ts
@@ -1,6 +1,5 @@
 import { StatusCodes } from 'http-status-codes'
 import { Document, Filter, ObjectId } from 'mongodb'
-import { ApiError } from 'next/dist/server/api-utils'
 import { Category } from '../../models/AsyncSelectorOption/Category'
 import { Exercise } from '../../models/AsyncSelectorOption/Exercise'
 import { Modifier } from '../../models/AsyncSelectorOption/Modifier'
@@ -13,6 +12,7 @@ import {
   MatchTypes,
   MongoQuery,
 } from '../../models/query-filters/MongoQuery'
+import { ApiError } from '../../models/ApiError'
 import { collections } from './mongoConnect'
 const {
   sessions,

--- a/lib/frontend/restService.ts
+++ b/lib/frontend/restService.ts
@@ -29,12 +29,6 @@ import {
 // Note: make sure any fetch() functions actually return after the fetch!
 // Otherwise there's no guarantee the write will be finished before it tries to read again...
 
-// todo: querystring's stringify is a bit sloppy when fields are undefined.
-// eg, {reps: undefined} => 'reps=&'. It doesn't affect the backend call though because
-// the validator filters that out. Might be ok to leave as is.
-// Also, note that stringify doesn't add the leading '?'.
-// See documentation: https://nodejs.org/api/querystring.html#querystringstringifyobj-sep-eq-options
-
 /** Parse a Query object into a rest param string. Query objects should be spread into this function. */
 export const paramify = (query: ParsedUrlQueryInput) => {
   const parsedQuery: ParsedUrlQueryInput = {}
@@ -43,6 +37,8 @@ export const paramify = (query: ParsedUrlQueryInput) => {
   for (const [key, value] of Object.entries(query)) {
     parsedQuery[key] = Array.isArray(value) && !value.length ? '' : value
   }
+  // note that stringify doesn't add the leading '?'.
+  // See documentation: https://nodejs.org/api/querystring.html#querystringstringifyobj-sep-eq-options
   return '?' + stringify(parsedQuery)
 }
 

--- a/lib/frontend/restService.ts
+++ b/lib/frontend/restService.ts
@@ -1,5 +1,4 @@
 import dayjs, { Dayjs } from 'dayjs'
-import { ApiError } from 'next/dist/server/api-utils'
 import { ParsedUrlQueryInput, stringify } from 'querystring'
 import useSWR, { SWRConfiguration } from 'swr'
 import { arrayToIndex, fetchJson } from '../../lib/util'
@@ -14,6 +13,7 @@ import BodyweightQuery from '../../models/query-filters/BodyweightQuery'
 import DateRangeQuery from '../../models/query-filters/DateRangeQuery'
 import { ExerciseQuery } from '../../models/query-filters/ExerciseQuery'
 import { RecordQuery } from '../../models/query-filters/RecordQuery'
+import { ApiError } from '../../models/ApiError'
 import {
   DATE_FORMAT,
   URI_BODYWEIGHT,

--- a/lib/testUtils.tsx
+++ b/lib/testUtils.tsx
@@ -10,12 +10,12 @@ import {
   NtarhInitPagesRouter,
   testApiHandler,
 } from 'next-test-api-route-handler'
-import { ApiError } from 'next/dist/server/api-utils'
 import { ReactElement, ReactNode } from 'react'
 import { SWRConfig } from 'swr'
 import { vi } from 'vitest'
 import { server } from '../msw-mocks/server'
 import { methodNotAllowed } from './backend/apiMiddleware/util'
+import { ApiError } from '../models/ApiError'
 
 // This file overwrites @testing-library's render and wraps it with components that
 // need to be set up for every test.

--- a/lib/testUtils.tsx
+++ b/lib/testUtils.tsx
@@ -154,7 +154,10 @@ export async function expectApiErrorsOnInvalidMethod({
       const res = await fetch({ method: method ?? 'OPTIONS' })
 
       expect(res.status).toBe(methodNotAllowed.statusCode)
-      expect(await res.json()).toBe(methodNotAllowed.message)
+      expect(await res.json()).toMatchObject({
+        message: methodNotAllowed.message,
+        statusCode: methodNotAllowed.statusCode,
+      })
     },
   })
 }

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -4,7 +4,7 @@ import { Exercise } from '../models/AsyncSelectorOption/Exercise'
 import { SetType } from '../models/Record'
 import { DB_UNITS, Set, Units } from '../models/Set'
 import { DATE_FORMAT } from './frontend/constants'
-import { ApiError } from 'next/dist/server/api-utils'
+import { ApiError } from '../models/ApiError'
 
 /** Manually create a globally unique id across all tables. This should be used for ALL new records.
  We want to manually handle the IDs so that ID generation is not tied to the specific database being used,

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -53,14 +53,13 @@ export const swrFetcher = (url: string) => fetchJson(url)
  */
 export const fetchJson = async <T>(...params: Parameters<typeof fetch>) => {
   const res = await fetch(...params)
-  const json: T = await res.json()
+  const json: T | ApiError = await res.json()
   if (res.ok) {
-    return json
+    return json as T
   }
-  throw new ApiError(
-    res.status,
-    (json as { message?: string }).message ?? 'unknown error'
-  )
+
+  const error = json as ApiError
+  throw new ApiError(res.status, error.message, error.details)
 }
 
 /** Capitalize first letter of a string.

--- a/models/ApiError.ts
+++ b/models/ApiError.ts
@@ -1,0 +1,18 @@
+import { ZodError } from 'zod'
+
+/** Error class returned from calls to the api.
+ *  Based on ApiError from next/dist/server/api-utils
+ */
+export class ApiError extends Error {
+  constructor(
+    public statusCode: number,
+    public message: string,
+    /** if the error is due to a validation issue,
+     *  details will provide more info about what is
+     *  malformed
+     */
+    public details?: ZodError[]
+  ) {
+    super(message)
+  }
+}

--- a/models/ApiError.ts
+++ b/models/ApiError.ts
@@ -1,3 +1,4 @@
+import { StatusCodes } from 'http-status-codes'
 import { ZodError } from 'zod'
 
 /** Error class returned from calls to the api.
@@ -5,8 +6,11 @@ import { ZodError } from 'zod'
  */
 export class ApiError extends Error {
   constructor(
-    public statusCode: number,
-    public message: string,
+    public statusCode = StatusCodes.INTERNAL_SERVER_ERROR,
+    /** The message extends the base Error message, so it should always be
+     *  accessed directly. If used in a spread it will not be visible.
+     */
+    public message = 'unknown error',
     /** if the error is due to a validation issue,
      *  details will provide more info about what is
      *  malformed


### PR DESCRIPTION
Creates a custom error instead of using the one from nextjs. The custom error includes `details` which shows a list of zod validation issues. Also improves consistency by returning the error object, not just a string of the message (previously if an unhandled error was returned the front end would not be able to parse it because it was looking for a string). 