### PR TITLE
fix bug preventing viewing new sessions

### DIFF
--- a/lib/frontend/restService.ts
+++ b/lib/frontend/restService.ts
@@ -1,7 +1,8 @@
 import dayjs, { Dayjs } from 'dayjs'
 import { ParsedUrlQueryInput, stringify } from 'querystring'
-import useSWR, { SWRConfiguration } from 'swr'
-import { arrayToIndex, fetchJson } from '../../lib/util'
+import useSWR from 'swr'
+import { arrayToIndex, fetchJson, fetchJsonNullable } from '../../lib/util'
+import { ApiError } from '../../models/ApiError'
 import { AsyncSelectorOption } from '../../models/AsyncSelectorOption'
 import { Category } from '../../models/AsyncSelectorOption/Category'
 import { Exercise } from '../../models/AsyncSelectorOption/Exercise'
@@ -13,7 +14,6 @@ import BodyweightQuery from '../../models/query-filters/BodyweightQuery'
 import DateRangeQuery from '../../models/query-filters/DateRangeQuery'
 import { ExerciseQuery } from '../../models/query-filters/ExerciseQuery'
 import { RecordQuery } from '../../models/query-filters/RecordQuery'
-import { ApiError } from '../../models/ApiError'
 import {
   DATE_FORMAT,
   URI_BODYWEIGHT,
@@ -65,14 +65,13 @@ const nameSort = <T extends { name: string }>(data?: T[]) =>
 // SESSION
 //---------
 
-export function useSessionLog(day: Dayjs | string, config?: SWRConfiguration) {
+export function useSessionLog(day: Dayjs | string) {
   const { data, error, isLoading, mutate } = useSWR<
     SessionLog | null,
     ApiError
-  >(
-    URI_SESSIONS + (typeof day === 'string' ? day : day.format(DATE_FORMAT)),
-    config
-  )
+  >(URI_SESSIONS + (typeof day === 'string' ? day : day.format(DATE_FORMAT)), {
+    fetcher: fetchJsonNullable,
+  })
 
   return {
     sessionLog: data,
@@ -134,10 +133,10 @@ export async function deleteSessionRecord(
  *
  *  Note that this applies to any other useSWR hook as well.
  */
-export function useRecord(id: string, config?: SWRConfiguration) {
+export function useRecord(id: string) {
   const { data, error, isLoading, mutate } = useSWR<Record | null, ApiError>(
     URI_RECORDS + id,
-    config
+    { fetcher: fetchJsonNullable }
   )
 
   return {
@@ -201,11 +200,11 @@ export function useExercises(query?: ExerciseQuery) {
   }
 }
 
-export function useExercise(id: string | null, config?: SWRConfiguration) {
+export function useExercise(id: string | null) {
   // passing null to useSWR disables fetching
   const { data, error, mutate } = useSWR<Exercise | null, ApiError>(
     id ? URI_EXERCISES + id : null,
-    config
+    { fetcher: fetchJsonNullable }
   )
 
   return {

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -1,10 +1,10 @@
 import dayjs from 'dayjs'
 import { v4 as uuid, validate, version } from 'uuid'
+import { ApiError } from '../models/ApiError'
 import { Exercise } from '../models/AsyncSelectorOption/Exercise'
 import { SetType } from '../models/Record'
 import { DB_UNITS, Set, Units } from '../models/Set'
 import { DATE_FORMAT } from './frontend/constants'
-import { ApiError } from '../models/ApiError'
 
 /** Manually create a globally unique id across all tables. This should be used for ALL new records.
  We want to manually handle the IDs so that ID generation is not tied to the specific database being used,
@@ -60,6 +60,25 @@ export const fetchJson = async <T>(...params: Parameters<typeof fetch>) => {
 
   const error = json as ApiError
   throw new ApiError(res.status, error.message, error.details)
+}
+
+/** The api will throw a 404 error if the requested resource is not found.
+ *  This function will ignore 404 errors and pass along null values.
+ *  It should only be used if null values are expected (typically for
+ *  a useSwr request of a single item, which assumes not found will
+ *  return null).)
+ */
+export const fetchJsonNullable = async <T>(
+  ...params: Parameters<typeof fetchJson>
+) => {
+  try {
+    return await fetchJson<T>(...params)
+  } catch (e) {
+    if (e instanceof ApiError && e.statusCode === 404) {
+      return null
+    }
+    throw e
+  }
 }
 
 /** Capitalize first letter of a string.


### PR DESCRIPTION
recent change making 404 an error instead of silently returning null was causing conflicts viewing dates with no sessions. These date pages had been relying on a null res to determine if they should show the new session. 

The api follows a standard convention of returning 404 on not found, but we need to account for useSwr expecting a null response if the resource is not found. Note: this only applies to single items; arrays will return as empty arrays. 