### PR TITLE
remove zod strictObject

### DIFF
--- a/lib/util.test.ts
+++ b/lib/util.test.ts
@@ -3,10 +3,10 @@ import {
   arrayToIndex,
   capitalize,
   generateId,
-  idSchema,
   removeUndefinedKeys,
   toArray,
 } from './util'
+import { idSchema } from '../models/schemas'
 
 describe('validateId', () => {
   it('throws error when id format is invalid', () => {

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -1,24 +1,14 @@
 import dayjs from 'dayjs'
-import { v4 as uuid, validate, version } from 'uuid'
+import { v4 as uuid } from 'uuid'
 import { ApiError } from '../models/ApiError'
 import { Exercise } from '../models/AsyncSelectorOption/Exercise'
 import { DATE_FORMAT } from './frontend/constants'
-import { z } from 'zod'
 
 /** Manually create a globally unique id across all tables. This should be used for ALL new records.
  We want to manually handle the IDs so that ID generation is not tied to the specific database being used,
  and to ensure no information is leaked from the ID (eg, userId=55 implies users 1-54 exist)
  */
 export const generateId = () => uuid()
-
-/** enforces an id is a uuid v4*/
-export const idSchema = z
-  .string()
-  .refine((id) => validate(id) && version(id) === 4)
-
-export const dateSchema = z.string().date()
-
-export const stringOrArraySchema = z.string().or(z.array(z.string()))
 
 // manually have to specify undefined is possible
 export type Index<T> = { [key: string]: T | undefined }

--- a/models/AsyncSelectorOption/Exercise.ts
+++ b/models/AsyncSelectorOption/Exercise.ts
@@ -1,16 +1,13 @@
 import { Filter } from 'mongodb'
 import { z } from 'zod'
 import { asyncSelectorOptionSchema, createAsyncSelectorOption } from '.'
-import {
-  removeUndefinedKeys,
-  stringOrArraySchema,
-  toArray,
-} from '../../lib/util'
+import { removeUndefinedKeys, toArray } from '../../lib/util'
 import { ArrayMatchType, buildMatchTypeFilter } from '../ArrayMatchType'
 import { attributesSchema } from '../Attributes'
 import { displayFieldsSchema } from '../DisplayFields'
 import { noteSchema } from '../Note'
 import { Status } from '../Status'
+import { stringOrArraySchema } from '../schemas'
 
 export interface Exercise extends z.infer<typeof exerciseSchema> {}
 export const exerciseSchema = asyncSelectorOptionSchema.extend({

--- a/models/AsyncSelectorOption/Exercise.ts
+++ b/models/AsyncSelectorOption/Exercise.ts
@@ -7,7 +7,7 @@ import { attributesSchema } from '../Attributes'
 import { displayFieldsSchema } from '../DisplayFields'
 import { noteSchema } from '../Note'
 import { Status } from '../Status'
-import { stringOrArraySchema } from '../schemas'
+import { apiArraySchema } from '../schemas'
 
 export interface Exercise extends z.infer<typeof exerciseSchema> {}
 export const exerciseSchema = asyncSelectorOptionSchema.extend({
@@ -45,8 +45,8 @@ export const exerciseQuerySchema = z
   .object({
     bodyweight: z.coerce.boolean(),
     unilateral: z.coerce.boolean(),
-    category: stringOrArraySchema,
-    modifier: stringOrArraySchema,
+    category: apiArraySchema,
+    modifier: apiArraySchema,
     status: z.nativeEnum(Status),
   })
   .partial()

--- a/models/AsyncSelectorOption/index.ts
+++ b/models/AsyncSelectorOption/index.ts
@@ -5,7 +5,7 @@ import { Status } from '../Status'
 export interface AsyncSelectorOption
   extends z.infer<typeof asyncSelectorOptionSchema> {}
 
-export const asyncSelectorOptionSchema = z.strictObject({
+export const asyncSelectorOptionSchema = z.object({
   _id: z.string(),
   name: z.string(),
   status: z.nativeEnum(Status),

--- a/models/Attributes.ts
+++ b/models/Attributes.ts
@@ -5,7 +5,7 @@ import { z } from 'zod'
  */
 export interface Attributes extends z.infer<typeof attributesSchema> {}
 
-export const attributesSchema = z.strictObject({
+export const attributesSchema = z.object({
   /** An exercise that includes bodyweight as a part of total weight lifted. */
   bodyweight: z.boolean().optional(),
   /** An exercise that is split into left and right sides which can be recorded separately. */

--- a/models/Bodyweight.ts
+++ b/models/Bodyweight.ts
@@ -17,7 +17,7 @@ export const weighInTypes = ['official', 'unofficial'] as const
 // instead of listing all the properties of the schema
 export interface Bodyweight extends z.infer<typeof bodyweightSchema> {}
 
-export const bodyweightSchema = z.strictObject({
+export const bodyweightSchema = z.object({
   _id: z.string(),
   value: z.number(),
   type: z.enum(weighInTypes),

--- a/models/DisplayFields.ts
+++ b/models/DisplayFields.ts
@@ -3,7 +3,7 @@ import { capitalize } from '../lib/util'
 import { DB_UNITS, Units, unitsSchema } from './Units'
 
 export interface VisibleField extends z.infer<typeof visibleFieldSchema> {}
-export const visibleFieldSchema = z.strictObject({
+export const visibleFieldSchema = z.object({
   name: unitsSchema.keyof().or(z.enum(['plateWeight', 'totalWeight'])),
   /** The visible label. Only needed if it is different than "name" */
   label: z.string().optional(),
@@ -29,7 +29,7 @@ export const visibleFieldSchema = z.strictObject({
 
 /** signifies which Set fields are visible, and which units they are using.  */
 export interface DisplayFields extends z.infer<typeof displayFieldsSchema> {}
-export const displayFieldsSchema = z.strictObject({
+export const displayFieldsSchema = z.object({
   /** ordered array that denotes which fields are active and in what order */
   visibleFields: z.array(visibleFieldSchema),
   /** must have units for all fields, not just visible ones.  */

--- a/models/Note.ts
+++ b/models/Note.ts
@@ -3,7 +3,7 @@ import { generateId } from '../lib/util'
 
 export interface Note extends z.infer<typeof noteSchema> {}
 
-export const noteSchema = z.strictObject({
+export const noteSchema = z.object({
   _id: z.string(),
   value: z.string(),
   tags: z.array(z.string()),

--- a/models/Record.ts
+++ b/models/Record.ts
@@ -8,7 +8,7 @@ import { exerciseSchema } from './AsyncSelectorOption/Exercise'
 import DateRangeQuery from './DateRangeQuery'
 import { noteSchema } from './Note'
 import { DEFAULT_SET_TYPE, setSchema, setTypeSchema } from './Set'
-import { stringOrArraySchema } from './schemas'
+import { apiArraySchema } from './schemas'
 
 // todo: add activeCategory (for programming)
 export interface Record extends z.infer<typeof recordSchema> {}
@@ -50,7 +50,7 @@ export interface RecordQuery extends z.input<typeof recordQuerySchema> {}
 export const recordQuerySchema = z
   .object({
     exercise: z.string(),
-    modifier: stringOrArraySchema,
+    modifier: apiArraySchema,
     modifierMatchType: z.nativeEnum(ArrayMatchType),
     // todo: refactor MatchType to remove Any. Any is just "don't pass in the fields"
     setTypeMatchType: z.nativeEnum(ArrayMatchType),

--- a/models/Record.ts
+++ b/models/Record.ts
@@ -16,7 +16,7 @@ import { DEFAULT_SET_TYPE, setSchema, setTypeSchema } from './Set'
 
 // todo: add activeCategory (for programming)
 export interface Record extends z.infer<typeof recordSchema> {}
-export const recordSchema = z.strictObject({
+export const recordSchema = z.object({
   _id: z.string(),
   date: z.string(),
   exercise: exerciseSchema.nullable(),
@@ -60,8 +60,7 @@ export const recordQuerySchema = z
     setTypeMatchType: z.nativeEnum(ArrayMatchType),
   })
   .partial()
-  // turn off strictObject
-  .and(setTypeSchema.strip().partial())
+  .and(setTypeSchema.partial())
   .transform(
     ({
       exercise,

--- a/models/Record.ts
+++ b/models/Record.ts
@@ -2,17 +2,13 @@ import dayjs from 'dayjs'
 import { Filter } from 'mongodb'
 import { z } from 'zod'
 import { DATE_FORMAT } from '../lib/frontend/constants'
-import {
-  generateId,
-  removeUndefinedKeys,
-  stringOrArraySchema,
-  toArray,
-} from '../lib/util'
+import { generateId, removeUndefinedKeys, toArray } from '../lib/util'
 import { ArrayMatchType, buildMatchTypeFilter } from './ArrayMatchType'
 import { exerciseSchema } from './AsyncSelectorOption/Exercise'
 import DateRangeQuery from './DateRangeQuery'
 import { noteSchema } from './Note'
 import { DEFAULT_SET_TYPE, setSchema, setTypeSchema } from './Set'
+import { stringOrArraySchema } from './schemas'
 
 // todo: add activeCategory (for programming)
 export interface Record extends z.infer<typeof recordSchema> {}

--- a/models/SessionLog.ts
+++ b/models/SessionLog.ts
@@ -6,7 +6,7 @@ import { Record } from './Record'
 // todo: add session time. Start / end times? Program stuff (not hashed out yet), overall notes?
 // todo: gym location?
 export interface SessionLog extends z.infer<typeof sessionLogSchema> {}
-export const sessionLogSchema = z.strictObject({
+export const sessionLogSchema = z.object({
   _id: z.string(),
   /** YYYY-MM-DD */
   date: z.string().date(),

--- a/models/Set.ts
+++ b/models/Set.ts
@@ -18,7 +18,7 @@ export interface Set extends z.infer<typeof setSchema> {}
 // plus overwrite "side"
 const dimensions = unitsSchema.keyof().exclude(['side']).options
 export const setSchema = z
-  .strictObject(
+  .object(
     dimensions.reduce(
       (prev, key) => ({ ...prev, [key]: z.number().nullish() }),
       // the key definition is the same idea as making a type from a const array
@@ -51,7 +51,7 @@ export const setOperators = [
  * This allows value/min/max to be saved when switching between operators.
  */
 export interface SetType extends z.infer<typeof setTypeSchema> {}
-export const setTypeSchema = z.strictObject({
+export const setTypeSchema = z.object({
   field: unitsSchema.keyof(),
   operator: z.enum(setOperators),
   value: z.coerce.number().optional(),

--- a/models/Units.ts
+++ b/models/Units.ts
@@ -5,7 +5,7 @@ import { TIME_FORMAT } from '../lib/frontend/constants'
  *  A unit with the same value as its key is considered to be unitless.
  */
 export interface Units extends z.infer<typeof unitsSchema> {}
-export const unitsSchema = z.strictObject({
+export const unitsSchema = z.object({
   weight: z.enum(['kg', 'lbs']),
   distance: z.enum(['m', 'km', 'ft', 'mi', 'cm', 'in']),
   /** Considered having a separate HH:mm:ss and mm:ss but then the latter

--- a/models/schemas.ts
+++ b/models/schemas.ts
@@ -1,0 +1,11 @@
+import { validate, version } from 'uuid'
+import { z } from 'zod'
+
+/** enforces an id is a uuid v4*/
+export const idSchema = z
+  .string()
+  .refine((id) => validate(id) && version(id) === 4)
+
+export const dateSchema = z.string().date()
+
+export const stringOrArraySchema = z.string().or(z.array(z.string()))

--- a/models/schemas.ts
+++ b/models/schemas.ts
@@ -4,7 +4,7 @@ import { z } from 'zod'
 /** enforces an id is a uuid v4*/
 export const idSchema = z
   .string()
-  .refine((id) => validate(id) && version(id) === 4)
+  .refine((id) => validate(id) && version(id) === 4, 'invalid id')
 
 /** enforces YYYY-MM-DD format */
 export const dateSchema = z.string().date()

--- a/models/schemas.ts
+++ b/models/schemas.ts
@@ -6,6 +6,8 @@ export const idSchema = z
   .string()
   .refine((id) => validate(id) && version(id) === 4)
 
+/** enforces YYYY-MM-DD format */
 export const dateSchema = z.string().date()
 
-export const stringOrArraySchema = z.string().or(z.array(z.string()))
+/** enforces api query param format, which may be string | string[] */
+export const apiArraySchema = z.string().or(z.array(z.string()))

--- a/pages/api/bodyweight-history/index.test.ts
+++ b/pages/api/bodyweight-history/index.test.ts
@@ -43,13 +43,6 @@ it('guards against missing fields', async () => {
   })
 })
 
-it('guards against extra fields', async () => {
-  await expectApiErrorsOnMalformedBody({
-    handler,
-    data: { ...data, extra: 'field' },
-  })
-})
-
 it('guards against invalid fields', async () => {
   await expectApiErrorsOnMalformedBody({
     handler,

--- a/pages/api/categories/[id].api.ts
+++ b/pages/api/categories/[id].api.ts
@@ -10,8 +10,8 @@ import {
   fetchCategory,
   updateCategoryFields,
 } from '../../../lib/backend/mongoService'
-import { idSchema } from '../../../lib/util'
 import { categorySchema } from '../../../models/AsyncSelectorOption/Category'
+import { idSchema } from '../../../models/schemas'
 
 async function handler(req: NextApiRequest, userId: UserId) {
   const id = idSchema.parse(req.query.id)

--- a/pages/api/categories/[id].test.ts
+++ b/pages/api/categories/[id].test.ts
@@ -63,14 +63,6 @@ it('guards against missing fields', async () => {
   })
 })
 
-it('guards against extra fields', async () => {
-  await expectApiErrorsOnMalformedBody({
-    handler,
-    params,
-    data: { ...data, extra: 'field' },
-  })
-})
-
 it('guards against invalid fields', async () => {
   await expectApiErrorsOnMalformedBody({
     handler,

--- a/pages/api/exercises/[id].api.ts
+++ b/pages/api/exercises/[id].api.ts
@@ -11,8 +11,8 @@ import {
   updateExercise,
   updateExerciseFields,
 } from '../../../lib/backend/mongoService'
-import { idSchema } from '../../../lib/util'
 import { exerciseSchema } from '../../../models/AsyncSelectorOption/Exercise'
+import { idSchema } from '../../../models/schemas'
 
 async function handler(req: NextApiRequest, userId: UserId) {
   const id = idSchema.parse(req.query.id)

--- a/pages/api/modifiers/[id].api.ts
+++ b/pages/api/modifiers/[id].api.ts
@@ -10,8 +10,8 @@ import {
   fetchModifier,
   updateModifierFields,
 } from '../../../lib/backend/mongoService'
-import { idSchema } from '../../../lib/util'
 import { modifierSchema } from '../../../models/AsyncSelectorOption/Modifier'
+import { idSchema } from '../../../models/schemas'
 
 async function handler(req: NextApiRequest, userId: UserId) {
   const id = idSchema.parse(req.query.id)

--- a/pages/api/modifiers/[id].test.ts
+++ b/pages/api/modifiers/[id].test.ts
@@ -59,14 +59,6 @@ it('guards against missing fields', async () => {
   })
 })
 
-it('guards against extra fields', async () => {
-  await expectApiErrorsOnMalformedBody({
-    handler,
-    params,
-    data: { ...data, extra: 'field' },
-  })
-})
-
 it('guards against invalid fields', async () => {
   await expectApiErrorsOnMalformedBody({
     handler,

--- a/pages/api/records/[id].api.ts
+++ b/pages/api/records/[id].api.ts
@@ -11,7 +11,7 @@ import {
   updateRecord,
   updateRecordFields,
 } from '../../../lib/backend/mongoService'
-import { idSchema } from '../../../lib/util'
+import { idSchema } from '../../../models/schemas'
 import { recordSchema } from '../../../models/Record'
 
 async function handler(req: NextApiRequest, userId: UserId) {

--- a/pages/api/sessions/[date].api.ts
+++ b/pages/api/sessions/[date].api.ts
@@ -9,8 +9,8 @@ import {
   fetchSession,
   updateSession,
 } from '../../../lib/backend/mongoService'
-import { dateSchema } from '../../../lib/util'
 import { sessionLogSchema } from '../../../models/SessionLog'
+import { dateSchema } from '../../../models/schemas'
 
 async function handler(req: NextApiRequest, userId: UserId) {
   const date = dateSchema.parse(req.query.date)

--- a/pages/sessions/[date].page.tsx
+++ b/pages/sessions/[date].page.tsx
@@ -10,7 +10,7 @@ import SessionSwiper from '../../components/session/SessionSwiper'
 import RestTimer from '../../components/session/upper/RestTimer'
 import TitleBar from '../../components/session/upper/TitleBar'
 import WeightUnitConverter from '../../components/session/upper/WeightUnitConverter'
-import { dateSchema } from '../../lib/util'
+import { dateSchema } from '../../models/schemas'
 
 export function getServerSideProps({ query }: GetServerSidePropsContext) {
   try {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,7 @@
     "types": ["vite/client", "vitest/globals"],
     "incremental": true
   },
-  "include": ["**/*.ts", "**/*.tsx", "eslint.config.js"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "eslint.config.js"],
   "exclude": [
     "node_modules",
     // cypress redefines jest assertion types. See: https://stackoverflow.com/a/69990369


### PR DESCRIPTION
Parsing via zod already strips away unrecognized keys. strictObject just throws an error if there are extra keys. Extra keys don't matter because the parsing process ensures we get the expected object shape. Some of the api queries rely on this -- the unparsed query object can contain values from multiple zod schemas which must be parsed with different schemas (eg, a record filter + date range).