### PR TITLE
update CI pipeline to run mongo scripts 

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,3 +1,4 @@
+name: CI
 on: pull_request
 jobs:
   e2e:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,4 +1,3 @@
-name: Tests
 on: pull_request
 jobs:
   e2e:
@@ -40,3 +39,18 @@ jobs:
         run: npm run lint
       - name: Vitest
         run: npm run test:once
+  scripts:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install packages
+        run: npm i
+      - name: Start MongoDB
+        uses: supercharge/mongodb-github-action@1.12.0
+        with:
+          mongodb-version: latest
+      - name: Generate dev data
+        run: npm run db:dev
+      - name: Generate test data
+        run: npm run db:test

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,3 +1,0 @@
-#!/usr/bin/env sh
-
-npm run test:once


### PR DESCRIPTION
This confirms the scripts haven't broken. We could potentially have test files that test the output of the scripts but we really only need to know that they run successfully. Otherwise we'd have to make assertions about the data which would make it cumbersome to update later.

Also removes husky pre-push hook that was running vitest since that is done in the CI pipeline now.