### PR TITLE
Add temp fix for useSwr not triggering rerender on TitleBar components

### DIFF
--- a/components/session/upper/TitleBar.tsx
+++ b/components/session/upper/TitleBar.tsx
@@ -13,6 +13,12 @@ export default function TitleBar({ day }: Props) {
   const router = useRouter()
   const theme = useTheme()
   const isMd = useMediaQuery(theme.breakpoints.up('md'))
+  // getServerSideProps messes up useSwr and prevents rerenders from
+  // being triggered for the bodyweight input and date picker, causing them to
+  // load infinitely. It only affects these useSwr calls.
+  // Other ones like useModifiers seem to still work due to nameSort().
+  // This is a tmp fix to force a rerender on small screens.
+  const _tmpLoadingFix = useMediaQuery(theme.breakpoints.down('md'))
 
   const handleDateChange = (newDay: Dayjs) => {
     const date = newDay.format(DATE_FORMAT)


### PR DESCRIPTION
There appears to be an issue with getServerSideProps for the session page where it is preventing useSwr fetches from triggering a rerender. Only the ones in the title bar are affected. A more permanent solution would be to either remove the serverSideProps and only useRouter (client side only), or convert everything to using serverSideProps for initial data (currently it's just validating the date). 