### PR TITLE
Setup parallel workers in playwright tests

### DIFF
--- a/pages/api/auth/[...nextauth].api.ts
+++ b/pages/api/auth/[...nextauth].api.ts
@@ -27,7 +27,7 @@ const devProvider =
 
       const objectIdSchema = z
         .string()
-        .regex(/^\d{24}$/, { message: 'Input must be a 24-digit number' })
+        .length(24, 'id must be 24 characters')
         .optional()
         .default(devUserId)
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,67 +1,64 @@
-import { defineConfig, devices } from '@playwright/test'
+import { defineConfig, devices, PlaywrightTestConfig } from '@playwright/test'
 
-/**
- * See https://playwright.dev/docs/test-configuration.
- */
+/** limited project list to run locally  */
+const localProjects: PlaywrightTestConfig['projects'] = [
+  {
+    name: 'chromium',
+    use: {
+      ...devices['Desktop Chrome'],
+    },
+  },
+  {
+    name: 'Mobile Safari',
+
+    use: { ...devices['iPhone 12'] },
+  },
+]
+
+/** extra projects to run in CI */
+const CIProjects: PlaywrightTestConfig['projects'] = [
+  {
+    name: 'firefox',
+    use: { ...devices['Desktop Firefox'] },
+  },
+  {
+    name: 'webkit',
+    use: { ...devices['Desktop Safari'] },
+  },
+  {
+    name: 'Mobile Chrome',
+    use: { ...devices['Pixel 5'] },
+  },
+]
+
+const isCI = !!process.env.CI
+
+// See: https://playwright.dev/docs/test-configuration.
 export default defineConfig({
   testDir: './playwright',
-  forbidOnly: !!process.env.CI,
-  retries: process.env.CI ? 2 : 0,
-  // todo: setup parallel workers so we can run multiple browsers.
-  // need to manage multiple logins / reset db between tests
-  // fullyParallel: true,
-  /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 1 : undefined,
-  /* See https://playwright.dev/docs/test-reporters */
-  reporter: process.env.CI ? 'github' : [['list'], ['list']],
-  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  forbidOnly: isCI,
+  retries: isCI ? 2 : 1,
+  // this runs individual tests in each file in parallel, which is causing
+  // test failures due to hitting the db simultaneously
+  fullyParallel: false,
+  // Opt out of parallel tests on CI for more reliability / avoid concurrency issues
+  workers: isCI ? 1 : undefined,
+  // See: https://playwright.dev/docs/test-reporters
+  reporter: isCI ? 'github' : [['list'], ['html']],
+  // Shared settings for all the projects below.
+  // See: https://playwright.dev/docs/api/class-testoptions.
   use: {
     baseURL: 'http://localhost:7357',
-    /** For CI. Local tests can use --ui to automatically create traces.
-     *  Traces show a ui view of what made the test fail.
-     *  See https://playwright.dev/docs/trace-viewer
-     */
+    // For CI. Local tests can use --ui to automatically create traces.
+    // Traces show a ui view of what made the test fail.
+    //  See: https://playwright.dev/docs/trace-viewer
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
   },
-  projects: [
-    {
-      name: 'chromium',
-      use: {
-        ...devices['Desktop Chrome'],
-      },
-    },
-    // {
-    //   name: 'firefox',
-    //   use: { ...devices['Desktop Firefox'] },
-    // },
-    // {
-    //   name: 'webkit',
-    //   use: { ...devices['Desktop Safari'] },
-    // },
-    /* Test against mobile viewports. */
-    // {
-    //   name: 'Mobile Chrome',
-    //   use: { ...devices['Pixel 5'] },
-    // },
-    {
-      name: 'Mobile Safari',
-
-      use: { ...devices['iPhone 12'] },
-    },
-    /* Test against branded browsers. */
-    // {
-    //   name: 'Microsoft Edge',
-    //   use: { ...devices['Desktop Edge'], channel: 'msedge' },
-    // },
-    // {
-    //   name: 'Google Chrome',
-    //   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
-    // },
-  ],
+  projects: localProjects.concat(isCI ? CIProjects : []),
   webServer: {
     command: 'npm run dev:test',
     url: 'http://localhost:7357',
-    reuseExistingServer: !process.env.CI,
+    reuseExistingServer: !isCI,
   },
 })

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,12 +1,5 @@
 import { defineConfig, devices } from '@playwright/test'
-import path from 'path'
-import { fileURLToPath } from 'url'
-import { dirname } from 'path'
 
-const __filename = fileURLToPath(import.meta.url)
-const __dirname = dirname(__filename)
-
-export const DEV_USER = path.join(__dirname, 'playwright/.cache/devUser.json')
 /**
  * See https://playwright.dev/docs/test-configuration.
  */
@@ -20,7 +13,7 @@ export default defineConfig({
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   /* See https://playwright.dev/docs/test-reporters */
-  reporter: process.env.CI ? 'github' : [['list'], ['html']],
+  reporter: process.env.CI ? 'github' : [['list'], ['list']],
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     baseURL: 'http://localhost:7357',
@@ -33,15 +26,9 @@ export default defineConfig({
   },
   projects: [
     {
-      name: 'setup',
-      testMatch: '**/*.setup.ts',
-    },
-    {
       name: 'chromium',
-      dependencies: ['setup'],
       use: {
         ...devices['Desktop Chrome'],
-        storageState: DEV_USER,
       },
     },
     // {
@@ -57,12 +44,11 @@ export default defineConfig({
     //   name: 'Mobile Chrome',
     //   use: { ...devices['Pixel 5'] },
     // },
-    // {
-    //   name: 'Mobile Safari',
-    //   dependencies: ['setup'],
+    {
+      name: 'Mobile Safari',
 
-    //   use: { ...devices['iPhone 12'], storageState: DEV_USER },
-    // },
+      use: { ...devices['iPhone 12'] },
+    },
     /* Test against branded browsers. */
     // {
     //   name: 'Microsoft Edge',

--- a/playwright/fixtures.ts
+++ b/playwright/fixtures.ts
@@ -1,0 +1,61 @@
+import { test as baseTest } from '@playwright/test'
+import fs from 'fs'
+import { ObjectId } from 'mongodb'
+import path from 'path'
+
+/** Generates a userId from a unique number.
+ *  The result is idempotent: the same number will
+ *  always correspond to the same id.
+ */
+const getUserId = (uniqueNum: number) =>
+  ObjectId.createFromTime(uniqueNum).toHexString()
+
+// This file is taken from the playwright docs.
+// See: https://playwright.dev/docs/auth#moderate-one-account-per-parallel-worker
+
+export * from '@playwright/test'
+export const test = baseTest.extend<object, { workerStorageState: string }>({
+  // Use the same storage state for all tests in this worker.
+  storageState: ({ workerStorageState }, apply) => apply(workerStorageState),
+  // Authenticate once per worker with a worker-scoped fixture.
+  workerStorageState: [
+    async ({ browser }, apply) => {
+      // Use parallelIndex as a unique identifier for each worker.
+      const id = test.info().parallelIndex
+      const fileName = path.resolve(
+        test.info().project.outputDir,
+        `.auth/${id}.json`
+      )
+
+      if (fs.existsSync(fileName)) {
+        // Reuse existing authentication state if any.
+        await apply(fileName)
+        return
+      }
+
+      // Important: make sure we authenticate in a clean environment by unsetting storage state.
+      const page = await browser.newPage({ storageState: undefined })
+
+      // Acquire a unique account, for example create a new one.
+      // Alternatively, you can have a list of precreated accounts for testing.
+      // Make sure that accounts are unique, so that multiple team members
+      // can run tests at the same time without interference.
+      // todo: ids are only unique based on the worker index
+      const userId = getUserId(id)
+
+      // Perform authentication steps.
+      // todo: can we reuse baseUrl to not have to repeat it here?
+      await page.goto('http://localhost:7357/api/auth/signin')
+      await page.getByRole('textbox', { name: 'user id' }).fill(userId)
+      await page.getByRole('button', { name: 'dev user' }).click()
+
+      // Wait until sign-in is complete
+      await page.waitForURL('http://localhost:7357')
+
+      await page.context().storageState({ path: fileName })
+      await page.close()
+      await apply(fileName)
+    },
+    { scope: 'worker' },
+  ],
+})

--- a/playwright/fixtures.ts
+++ b/playwright/fixtures.ts
@@ -20,8 +20,11 @@ export const test = baseTest.extend<object, { workerStorageState: string }>({
   // Authenticate once per worker with a worker-scoped fixture.
   workerStorageState: [
     async ({ browser }, apply) => {
-      // Use parallelIndex as a unique identifier for each worker.
-      const id = test.info().parallelIndex
+      // Workers have workerIndex and parallelIndex as unique ids.
+      // The difference is parallelIndex will remain the same if the worker is
+      // restarted (eg, due to a failure), but workerIndex will be regenerated.
+      const id = test.info().workerIndex
+
       const fileName = path.resolve(
         test.info().project.outputDir,
         `.auth/${id}.json`
@@ -40,7 +43,6 @@ export const test = baseTest.extend<object, { workerStorageState: string }>({
       // Alternatively, you can have a list of precreated accounts for testing.
       // Make sure that accounts are unique, so that multiple team members
       // can run tests at the same time without interference.
-      // todo: ids are only unique based on the worker index
       const userId = getUserId(id)
 
       // Perform authentication steps.

--- a/playwright/login.setup.ts
+++ b/playwright/login.setup.ts
@@ -1,9 +1,0 @@
-import { test } from '@playwright/test'
-import { DEV_USER } from '../playwright.config'
-
-test('login', async ({ page }) => {
-  await page.goto('api/auth/signin')
-  await page.getByRole('button', { name: 'dev user' }).click()
-
-  await page.context().storageState({ path: DEV_USER })
-})

--- a/playwright/manage.test.ts
+++ b/playwright/manage.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test'
+import { expect, test } from './fixtures'
 
 test('adds an exercise', async ({ page }) => {
   // should default to exercise tab

--- a/playwright/navigation.test.ts
+++ b/playwright/navigation.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test'
+import { test, expect } from './fixtures'
 import dayjs from 'dayjs'
 import { DATE_FORMAT } from '../lib/frontend/constants'
 
@@ -8,9 +8,14 @@ test(`navigates to today's session from home page`, async ({ page }) => {
 
   const today = dayjs()
 
-  await expect(page.getByRole('textbox', { name: 'Date' })).toHaveValue(
-    today.format('MM/DD/YYYY')
-  )
+  // mobile and desktop have different labels for the date picker
+  // due to mobile not showing the date select button, so mobile conflicts
+  // with the previous session picker for copying sessions
+  // Desktop: "Date"
+  // Mobile: "Choose date, selected date is Apr 23, 2025"
+  await expect(
+    page.locator(`input[value="${today.format('MM/DD/YYYY')}"]`)
+  ).toBeVisible()
   expect(page.url().includes(today.format(DATE_FORMAT)))
 })
 


### PR DESCRIPTION
Creates a new user for each worker so playwright can run a separate user for each browser, ensuring db interactions do not interfere with other tests. 

Enables multiple test runners, including mobile + desktop environments.