### PR TITLE
tweak playwright config 

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -28,12 +28,6 @@ jobs:
           # renamed to AUTH_SECRET in authjs v5
           NEXTAUTH_SECRET: ${{ secrets.AUTH_SECRET }}
         run: npx playwright test
-      - uses: actions/upload-artifact@v4
-        if: ${{ !cancelled() }}
-        with:
-          name: playwright-report
-          path: playwright-report/
-          retention-days: 30
 
   frontend:
     runs-on: ubuntu-latest

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -38,8 +38,8 @@ export default defineConfig({
   testDir: './playwright',
   forbidOnly: isCI,
   retries: isCI ? 2 : 1,
-  // this runs individual tests in each file in parallel, which is causing
-  // test failures due to hitting the db simultaneously
+  // Runs individual tests in each file in parallel.
+  // Has proven to be too unstable to use; causes a lot of flakiness.
   fullyParallel: false,
   // Opt out of parallel tests on CI for more reliability / avoid concurrency issues
   workers: isCI ? 1 : undefined,
@@ -59,6 +59,8 @@ export default defineConfig({
   webServer: {
     command: 'npm run dev:test',
     url: 'http://localhost:7357',
+    // NOTE: in dev mode it's much more stable to run the test server separately.
+    // Playwright can spin up the server on its own but it frequently causes flakiness.
     reuseExistingServer: !isCI,
   },
 })

--- a/playwright/manage.test.ts
+++ b/playwright/manage.test.ts
@@ -13,10 +13,12 @@ test('adds an exercise', async ({ page }) => {
   // -----------
 
   // note: fill clears existing text in the input
-  await page.getByLabel('Name').fill('SSB squats')
+  const newName = 'SSB squats'
+  await page.getByLabel('Name').fill(newName)
   await page.getByRole('button', { name: 'Submit' }).click()
-  // name change should update name/exercise inputs and url
-  await expect(page.locator('input[value="SSB squats"]')).toHaveCount(2)
+  // name change should immediately update name/exercise inputs and url
+  await expect(page.getByLabel('Exercise')).toHaveValue(newName)
+  await expect(page.getByLabel('Name')).toHaveValue(newName)
   await expect(page).toHaveURL(/SSB\+squats/)
 
   await page.getByText('Active').click()
@@ -32,8 +34,8 @@ test('adds an exercise', async ({ page }) => {
   // confirm edits persist on reload
   await page.reload()
 
-  await expect(page.getByLabel('Exercise')).toHaveValue('SSB squats')
-  await expect(page.getByLabel('Name')).toHaveValue('SSB squats')
+  await expect(page.getByLabel('Exercise')).toHaveValue(newName)
+  await expect(page.getByLabel('Name')).toHaveValue(newName)
   await expect(page.getByText('Archived')).toBeVisible()
   await expect(page.getByLabel('Equipment weight')).toHaveValue('7.5')
   await expect(page.getByLabel('Bodyweight')).toBeChecked()


### PR DESCRIPTION
small tweaks to attempt to reduce flakiness. Local test runner can have a significant amount of flake which seems to be caused by having playwright spin up the test server itself instead of reusing the existing server. Unsure if this is fixable but it can largely be avoided by starting the test server before running pw tests, or running with a single worker.