### PR TITLE
Add pw tests for session redirect and loaded session data

### DIFF
--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -1,16 +1,17 @@
-/** next lint requires us to pass each staged file name prefixed with "--file".
- * Normally lint-staged simply appends all file names to the end of the command you
- * provide, so we have to manually build the command to include the "--file" option.
- */
-const buildNextLintCommand = (filenames) =>
-  `npx next lint --fix --file ${filenames.join(' --file ')}`
+// lintstaged appends a list of all the staged files at the end of any commands
+// given to it, so the commands must support multiple files in a list like that.
+// Otherwise, a function can be passed instead of a string, which will have the
+// list of staged filenames as an arg.
 
 const prettier = 'npx prettier --write'
+// we must explicitly null out the dirs or it will still lint over all the dirs
+// specified in next.config.js
+const lint = 'npx next lint --fix --dir --file'
 
 // tasks are run in parallel, but they MUST have mutually exclusive matchers
 // to avoid multiple tasks writing to the same file
 export default {
-  '*.{ts,tsx}': [buildNextLintCommand, prettier],
+  '*.{ts,tsx}': [lint, prettier],
   // js files are usually jsut config for external pkgs, so we don't lint them
   '*.js': [prettier],
 }

--- a/components/session/upper/BodyweightInput.test.tsx
+++ b/components/session/upper/BodyweightInput.test.tsx
@@ -73,7 +73,7 @@ describe('input', () => {
   it('shows reset and submit buttons when input value is different than existing value', async () => {
     useServer(URI_BODYWEIGHT, [officialBw2000])
     const { user } = render(<BodyweightInput day={date2020} />)
-    const input = screen.getByLabelText('bodyweight input')
+    const input = screen.getByLabelText('Bodyweight')
     await screen.findByText(/official/i)
 
     await user.type(input, '{End}3')
@@ -93,7 +93,7 @@ describe('input', () => {
   it('does not show submit button when latest bodyweight is unchanged and matches current date', async () => {
     useServer(URI_BODYWEIGHT, [officialBw2000])
     const { user } = render(<BodyweightInput day={date2000} />)
-    const input = screen.getByLabelText('bodyweight input')
+    const input = screen.getByLabelText('Bodyweight')
     await screen.findByText(/official/i)
 
     await user.type(input, '{End}3')
@@ -112,7 +112,7 @@ describe('input', () => {
   it('validates against changing an existing value to be empty', async () => {
     useServer(URI_BODYWEIGHT, [officialBw2000])
     const { user } = render(<BodyweightInput day={date2020} />)
-    const input = screen.getByLabelText('bodyweight input')
+    const input = screen.getByLabelText('Bodyweight')
     await screen.findByText(/official/i)
 
     await user.type(input, '{End}{Backspace}{Backspace}')
@@ -124,7 +124,7 @@ describe('input', () => {
   it('resets to existing value when button is clicked', async () => {
     useServer(URI_BODYWEIGHT, [officialBw2000])
     const { user } = render(<BodyweightInput day={date2020} />)
-    const input = screen.getByLabelText('bodyweight input')
+    const input = screen.getByLabelText('Bodyweight')
     await screen.findByText(/official/i)
 
     await user.type(input, '3')
@@ -138,7 +138,7 @@ describe('input', () => {
   it('submits and revalidates when button is clicked', async () => {
     useServer(URI_BODYWEIGHT, [officialBw2000])
     const { user } = render(<BodyweightInput day={date2020} />)
-    const input = screen.getByLabelText('bodyweight input')
+    const input = screen.getByLabelText('Bodyweight')
     await screen.findByText(/official/i)
 
     // simulate the res from revalidation is different from UI value

--- a/components/session/upper/BodyweightInput.tsx
+++ b/components/session/upper/BodyweightInput.tsx
@@ -77,7 +77,6 @@ export default function BodyweightInput({
         },
         input: {
           readOnly: loading,
-          'aria-label': 'bodyweight input',
           // without the box the loading spinner has an uneven width
           startAdornment: (
             <>

--- a/pages/sessions/index.page.tsx
+++ b/pages/sessions/index.page.tsx
@@ -8,9 +8,15 @@ import { DATE_FORMAT } from '../../lib/frontend/constants'
 
 export default function Page() {
   const router = useRouter()
-  // initial value is undefined while loading
-  const [sessionRedirect, setSessionRedirect] =
-    useLocalStorageState('sessionRedirect')
+  const [sessionRedirect, setSessionRedirect] = useLocalStorageState(
+    'sessionRedirect',
+    // serverValue is the value on the initial render from the server.
+    // We needed a distinct state separate from true/false to indicate "loading".
+    // We cannot use undefined because then the hook just reuses defaultValue for
+    // defaultServerValue. We need default values in case the value is not
+    // saved in local storage yet.
+    { defaultServerValue: null, defaultValue: true }
+  )
 
   // need to wrap router.push in a useEffect because otherwise it would try to
   // render serverside and cause an error since the router doesn't exist yet.
@@ -20,7 +26,7 @@ export default function Page() {
     router.push(`sessions/${today}`)
   }, [router, sessionRedirect])
 
-  return sessionRedirect || sessionRedirect === undefined ? (
+  return sessionRedirect !== false ? (
     <>
       <LoadingSpinner />
     </>
@@ -29,16 +35,16 @@ export default function Page() {
       <Typography variant="h6" component="h1" py={1} textAlign="center">
         No Session
       </Typography>
-      <Typography>
+      <Typography textAlign="center">
         Normally coming here would redirect to the page for today's session, but
-        the redirect has been disabled!
+        the redirect has been disabled.
       </Typography>
       <div></div>
-      <Typography>
+      <Typography textAlign="center">
         Typically you might want to turn off the redirect temporarily to
         bookmark this page.
       </Typography>
-      <Typography>
+      <Typography textAlign="center">
         You can re-enable the redirect through settings, or by clicking the
         button below.
       </Typography>

--- a/pages/settings.page.tsx
+++ b/pages/settings.page.tsx
@@ -1,5 +1,6 @@
 import { FormControlLabel, FormGroup, Switch, Typography } from '@mui/material'
 import Grid from '@mui/material/Grid2'
+import Link from 'next/link'
 import useLocalStorageState from 'use-local-storage-state'
 
 export default function SettingsPage() {
@@ -18,12 +19,15 @@ export default function SettingsPage() {
                 onChange={() => setSessionRedirect(!sessionRedirect)}
               />
             }
-            label="Redirect to today's session"
+            label="Session redirect"
           />
           <Typography variant="body2">
-            Redirect to today's session when when navigating to the sessions
-            page with no date in the url. Disabling this can be useful for
-            directly bookmarking the redirect page.
+            Redirects to today's session when when navigating to the{' '}
+            <Link href="/sessions" className="default-link">
+              sessions page
+            </Link>{' '}
+            with no date in the url. Temporarily disabling this can be useful
+            for directly bookmarking the redirect page.
           </Typography>
         </FormGroup>
       </Grid>

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -37,7 +37,7 @@ const isCI = !!process.env.CI
 export default defineConfig({
   testDir: './playwright',
   forbidOnly: isCI,
-  retries: isCI ? 2 : 0,
+  retries: isCI ? 2 : 1,
   // Runs individual tests in each file in parallel.
   // Has proven to be too unstable to use; causes a lot of flakiness.
   fullyParallel: false,

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -37,12 +37,17 @@ const isCI = !!process.env.CI
 export default defineConfig({
   testDir: './playwright',
   forbidOnly: isCI,
-  retries: isCI ? 2 : 1,
+  retries: isCI ? 2 : 0,
   // Runs individual tests in each file in parallel.
   // Has proven to be too unstable to use; causes a lot of flakiness.
   fullyParallel: false,
   // Opt out of parallel tests on CI for more reliability / avoid concurrency issues
   workers: isCI ? 1 : undefined,
+  // tests frequently max out the default timeouts
+  timeout: 60_000,
+  expect: {
+    timeout: 10_000,
+  },
   // See: https://playwright.dev/docs/test-reporters
   reporter: isCI ? 'github' : [['list'], ['html']],
   // Shared settings for all the projects below.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -44,7 +44,7 @@ export default defineConfig({
   // Opt out of parallel tests on CI for more reliability / avoid concurrency issues
   workers: isCI ? 1 : undefined,
   // tests frequently max out the default timeouts
-  timeout: 60_000,
+  timeout: 45_000,
   expect: {
     timeout: 10_000,
   },

--- a/playwright/manage.test.ts
+++ b/playwright/manage.test.ts
@@ -34,7 +34,10 @@ test('adds an exercise', async ({ page }) => {
   // confirm edits persist on reload
   await page.reload()
 
-  await expect(page.getByLabel('Exercise')).toHaveValue(newName)
+  await expect(page.getByLabel('Exercise')).toHaveValue(newName, {
+    // reload seems to frequently be the cause of test timeouts
+    timeout: 15_000,
+  })
   await expect(page.getByLabel('Name')).toHaveValue(newName)
   await expect(page.getByText('Archived')).toBeVisible()
   await expect(page.getByLabel('Equipment weight')).toHaveValue('7.5')

--- a/playwright/navigation.test.ts
+++ b/playwright/navigation.test.ts
@@ -16,6 +16,7 @@ test(`navigates to today's session from home page`, async ({ page }) => {
   await expect(
     page.locator(`input[value="${today.format('MM/DD/YYYY')}"]`)
   ).toBeVisible()
+  // page.url() is synchronous. To wait for a url use page.waitForUrl().
   expect(page.url().includes(today.format(DATE_FORMAT)))
 })
 

--- a/playwright/sessions.test.ts
+++ b/playwright/sessions.test.ts
@@ -20,7 +20,7 @@ test('loads calendar', async ({ page }) => {
 
   // open date picker -- have to specifically click the picker's label.
   // On desktop there is a distinct icon, but on mobile the whole input opens the picker.
-  await page.getByLabel('Choose date').click()
+  await page.getByLabel('selected date is Jan 1').click()
 
   // pick an arbitrary date to confirm the calendar is loaded
   await expect(page.getByRole('gridcell', { name: '15' })).toBeVisible()

--- a/playwright/sessions.test.ts
+++ b/playwright/sessions.test.ts
@@ -14,6 +14,18 @@ test('adds bodyweight', async ({ page }) => {
   await expect(page.getByText('Using latest official weight')).toBeVisible()
 })
 
+// todo: make 2 records and swap between the sessions
+test('loads calendar', async ({ page }) => {
+  await page.goto('/sessions/2000-01-01')
+
+  // open date picker -- have to specifically click the picker's label.
+  // On desktop there is a distinct icon, but on mobile the whole input opens the picker.
+  await page.getByLabel('Choose date').click()
+
+  // pick an arbitrary date to confirm the calendar is loaded
+  await expect(page.getByRole('gridcell', { name: '15' })).toBeVisible()
+})
+
 // The redirect is stored in local storage. This value is set in the settings
 // page, but it should redirect by default without first visiting settings
 // to set the value.

--- a/playwright/sessions.test.ts
+++ b/playwright/sessions.test.ts
@@ -1,0 +1,27 @@
+import dayjs from 'dayjs'
+import { DATE_FORMAT } from '../lib/frontend/constants'
+import { expect, test } from './fixtures'
+
+test('adds bodyweight', async ({ page }) => {
+  await page.goto('/sessions/2000-01-01')
+
+  // bodyweight is done loading
+  await expect(page.getByText('No existing official weigh-ins')).toBeVisible()
+
+  await page.getByLabel('Bodyweight', { exact: true }).fill('50')
+  await page.getByRole('button', { name: 'Submit' }).click()
+
+  // bw has updated
+  await expect(page.getByLabel('Bodyweight', { exact: true })).toHaveValue('50')
+  await expect(page.getByText('Using latest official weight')).toBeVisible()
+})
+
+// The redirect is stored in local storage. This value is set in the settings
+// page, but it should redirect by default without first visiting settings
+// to set the value.
+test.skip(`redirects to today's log if url has no date`, async ({ page }) => {
+  await page.goto('/sessions')
+
+  const today = dayjs().format(DATE_FORMAT)
+  expect(page.url()).toContain(today)
+})

--- a/playwright/sessions.test.ts
+++ b/playwright/sessions.test.ts
@@ -1,5 +1,3 @@
-import dayjs from 'dayjs'
-import { DATE_FORMAT } from '../lib/frontend/constants'
 import { expect, test } from './fixtures'
 
 test('adds bodyweight', async ({ page }) => {
@@ -19,9 +17,24 @@ test('adds bodyweight', async ({ page }) => {
 // The redirect is stored in local storage. This value is set in the settings
 // page, but it should redirect by default without first visiting settings
 // to set the value.
-test.skip(`redirects to today's log if url has no date`, async ({ page }) => {
+test(`redirects to today's log if url has no date`, async ({ page }) => {
   await page.goto('/sessions')
 
-  const today = dayjs().format(DATE_FORMAT)
-  expect(page.url()).toContain(today)
+  await expect(page.getByText('Copy session')).toBeVisible()
+})
+
+test(`follows session redirect setting`, async ({ page }) => {
+  await page.goto('/settings')
+
+  // disable redirect
+  await page.getByLabel('redirect').click()
+  await page.getByText('sessions page').click()
+
+  // shows no redirect page
+  const enableRedirectButton = page.getByText('enable redirect')
+  await expect(enableRedirectButton).toBeVisible()
+  await enableRedirectButton.click()
+
+  // redirects
+  await expect(page.getByText('Copy session')).toBeVisible()
 })

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -22,6 +22,12 @@ a {
   text-decoration: none;
 }
 
+/* default href link styling */
+.default-link {
+  color: blue;
+  text-decoration: underline;
+}
+
 /* disable spinner buttons on numeric input */
 
 /* Chrome, Safari, Edge, Opera */


### PR DESCRIPTION
Adds tests for session page:
- session redirect works by default and can be disabled
- bodyweight and date picker load data and are not permanently in a loading state