### PR TITLE
simplify apiArraySchema

### DIFF
--- a/components/history/QueryForm.tsx
+++ b/components/history/QueryForm.tsx
@@ -4,12 +4,13 @@ import isEqual from 'react-fast-compare'
 import NumericFieldAutosave from '../../components/form-fields/NumericFieldAutosave'
 import RecordExerciseSelector from '../../components/session/records/RecordExerciseSelector'
 import useDisplayFields from '../../lib/frontend/useDisplayFields'
-import { toArray, UpdateState } from '../../lib/util'
+import { UpdateState } from '../../lib/util'
 import { Exercise } from '../../models/AsyncSelectorOption/Exercise'
 import {
   DEFAULT_RECORD_HISTORY_QUERY,
   RecordRangeQuery,
 } from '../../models/Record'
+import { apiArraySchema } from '../../models/schemas'
 import ModifierQueryField from './ModifierQueryField'
 import QueryDateRangePicker from './QueryDateRangePicker'
 import SetTypeQueryField from './SetTypeQueryField'
@@ -46,7 +47,7 @@ export default function QueryCard({ query, setQuery }: Props) {
             })
           }
         }}
-        activeModifiers={toArray(unsavedQuery.modifier)}
+        activeModifiers={apiArraySchema.parse(unsavedQuery.modifier)}
         exercise={exercise}
         category={null}
         variant="outlined"
@@ -55,7 +56,7 @@ export default function QueryCard({ query, setQuery }: Props) {
         disabled={!exercise}
         matchType={unsavedQuery.modifierMatchType}
         options={exercise?.modifiers || []}
-        initialValue={toArray(unsavedQuery.modifier)}
+        initialValue={apiArraySchema.parse(unsavedQuery.modifier)}
         updateQuery={updateUnsavedQuery}
       />
       <SetTypeQueryField

--- a/lib/util.test.ts
+++ b/lib/util.test.ts
@@ -1,12 +1,11 @@
 import { v6 as uuidv6 } from 'uuid'
+import { idSchema } from '../models/schemas'
 import {
   arrayToIndex,
   capitalize,
   generateId,
   removeUndefinedKeys,
-  toArray,
 } from './util'
-import { idSchema } from '../models/schemas'
 
 describe('validateId', () => {
   it('throws error when id format is invalid', () => {
@@ -75,19 +74,5 @@ describe('removeUndefinedKeys', () => {
     expect(removeUndefinedKeys({ a: { b: undefined } })).toEqual({
       a: { b: undefined },
     })
-  })
-})
-
-describe('toArray', () => {
-  it('returns singleton as an array', () => {
-    expect(toArray('hi')).toEqual(['hi'])
-  })
-
-  it('returns undefined as an empty array', () => {
-    expect(toArray(undefined)).toEqual([])
-  })
-
-  it('returns array as itself', () => {
-    expect(toArray(['hi'])).toEqual(['hi'])
   })
 })

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -77,10 +77,6 @@ export const removeUndefinedKeys = <T extends object>(obj: T) =>
     {}
   )
 
-/** converts a value that may be a singleton or array into an array */
-export const toArray = <T>(value: T | T[] | undefined) =>
-  Array.isArray(value) ? value : value ? [value] : []
-
 export const enqueueError = (
   e: unknown,
   /** message to show if the error is a validation error */

--- a/models/AsyncSelectorOption/Exercise.ts
+++ b/models/AsyncSelectorOption/Exercise.ts
@@ -1,7 +1,7 @@
 import { Filter } from 'mongodb'
 import { z } from 'zod'
 import { asyncSelectorOptionSchema } from '.'
-import { generateId, removeUndefinedKeys, toArray } from '../../lib/util'
+import { generateId, removeUndefinedKeys } from '../../lib/util'
 import { ArrayMatchType, buildMatchTypeFilter } from '../ArrayMatchType'
 import { attributesSchema } from '../Attributes'
 import { displayFieldsSchema } from '../DisplayFields'
@@ -60,14 +60,8 @@ export const exerciseQuerySchema = z
     const filter: Filter<Exercise> = {
       ...rest,
       // it only makes sense to query exercises with a partial array match
-      categories: buildMatchTypeFilter(
-        toArray(category),
-        ArrayMatchType.Partial
-      ),
-      modifiers: buildMatchTypeFilter(
-        toArray(modifier),
-        ArrayMatchType.Partial
-      ),
+      categories: buildMatchTypeFilter(category, ArrayMatchType.Partial),
+      modifiers: buildMatchTypeFilter(modifier, ArrayMatchType.Partial),
       'attributes.unilateral': unilateral,
       'attributes.bodyweight': bodyweight,
     }

--- a/models/Record.ts
+++ b/models/Record.ts
@@ -2,7 +2,7 @@ import dayjs from 'dayjs'
 import { Filter } from 'mongodb'
 import { z } from 'zod'
 import { DATE_FORMAT } from '../lib/frontend/constants'
-import { generateId, removeUndefinedKeys, toArray } from '../lib/util'
+import { generateId, removeUndefinedKeys } from '../lib/util'
 import { ArrayMatchType, buildMatchTypeFilter } from './ArrayMatchType'
 import { exerciseSchema } from './AsyncSelectorOption/Exercise'
 import DateRangeQuery from './DateRangeQuery'
@@ -84,10 +84,7 @@ export const recordQuerySchema = z
         ...rest,
         ...setTypeFields,
         'exercise.name': exercise,
-        activeModifiers: buildMatchTypeFilter(
-          toArray(modifier),
-          modifierMatchType
-        ),
+        activeModifiers: buildMatchTypeFilter(modifier, modifierMatchType),
       }
 
       return removeUndefinedKeys(filter)

--- a/models/schemas.ts
+++ b/models/schemas.ts
@@ -9,5 +9,10 @@ export const idSchema = z
 /** enforces YYYY-MM-DD format */
 export const dateSchema = z.string().date()
 
-/** enforces api query param format, which may be string | string[] */
-export const apiArraySchema = z.string().or(z.array(z.string()))
+/** enforces api query param format, which may be string | string[],
+ *  and transforms to a string[]
+ */
+export const apiArraySchema = z
+  .string()
+  .transform((str) => [str])
+  .or(z.array(z.string()))


### PR DESCRIPTION
transform strings to arrays in the schema to avoid needing the toArray util function