### PR TITLE
Add pw test for session badges

### DIFF
--- a/components/session/upper/SessionDatePicker.test.tsx
+++ b/components/session/upper/SessionDatePicker.test.tsx
@@ -42,9 +42,9 @@ it('shows existing session data with badges', async () => {
 
   expect(screen.getByLabelText('2020-01-05, Session data exists')).toBeVisible()
   // session exists, but is empty -- should be displayed as "no session"
-  expect(screen.getByLabelText('2020-01-10, No session')).toBeVisible()
+  expect(screen.getByLabelText('2020-01-10, No session data')).toBeVisible()
   // no session exists
-  expect(screen.getByLabelText('2020-01-04, No session')).toBeVisible()
+  expect(screen.getByLabelText('2020-01-04, No session data')).toBeVisible()
 })
 
 it('handles changing month', async () => {

--- a/components/session/upper/SessionDatePicker.tsx
+++ b/components/session/upper/SessionDatePicker.tsx
@@ -10,6 +10,7 @@ import { preload } from 'swr'
 import { DATE_FORMAT, URI_SESSIONS } from '../../../lib/frontend/constants'
 import { paramify, useSessionLogs } from '../../../lib/frontend/restService'
 import { swrFetcher } from '../../../lib/util'
+import useCurrentSessionLog from '../useCurrentSessionLog'
 
 // The query gets data for the current month +/- 1 month so that
 // data for daysOutsideCurrentMonth is still visible on the current month
@@ -67,6 +68,8 @@ function SessionDatePickerInner({
   const { sessionLogsIndex, isLoading } = useSessionLogs(
     buildSessionLogQuery(0, visibleMonth)
   )
+  const { records: currentRecords, sessionLog: currentSession } =
+    useCurrentSessionLog()
 
   const handleChange = (newPickerValue: Dayjs | null) => {
     if (newPickerValue?.isValid()) {
@@ -109,7 +112,12 @@ function SessionDatePickerInner({
       slots={{
         day: (DayComponentProps) => {
           const day = DayComponentProps.day.format(DATE_FORMAT)
-          const isBadgeVisible = sessionLogsIndex[day]?.records.length
+          // the index will not be updated for the current day if user creates a new
+          // session by creating a record
+          const isCurrentDay = day === currentSession?.date
+          const isBadgeVisible = isCurrentDay
+            ? currentRecords?.length
+            : sessionLogsIndex[day]?.records.length
           // todo: can populate this with more info, like session type (after that's implemented)
           return (
             <Badge
@@ -118,7 +126,7 @@ function SessionDatePickerInner({
               variant="dot"
               color="secondary"
               aria-label={`${day}, ${
-                isBadgeVisible ? 'Session data exists' : 'No session'
+                isBadgeVisible ? 'Session data exists' : 'No session data'
               }`}
               invisible={!isBadgeVisible}
             >

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -41,8 +41,6 @@ export default defineConfig({
   // Runs individual tests in each file in parallel.
   // Has proven to be too unstable to use; causes a lot of flakiness.
   fullyParallel: false,
-  // Opt out of parallel tests on CI for more reliability / avoid concurrency issues
-  workers: isCI ? 1 : undefined,
   // tests frequently max out the default timeouts
   timeout: 45_000,
   expect: {

--- a/playwright/fixtures/Api.ts
+++ b/playwright/fixtures/Api.ts
@@ -1,0 +1,51 @@
+import type { APIRequestContext } from '@playwright/test'
+import {
+  URI_BODYWEIGHT,
+  URI_EXERCISES,
+  URI_MODIFIERS,
+  URI_RECORDS,
+} from '../../lib/frontend/constants'
+import {
+  createExercise,
+  Exercise,
+} from '../../models/AsyncSelectorOption/Exercise'
+import {
+  createModifier,
+  Modifier,
+} from '../../models/AsyncSelectorOption/Modifier'
+import { Bodyweight, createBodyweight } from '../../models/Bodyweight'
+import { createRecord, Record } from '../../models/Record'
+
+export class Api {
+  constructor(public readonly request: APIRequestContext) {}
+
+  post = (uri: string, data: unknown) =>
+    // if we don't fail when the status is not ok the data will just silently
+    // not be saved to db
+    this.request.post(uri, { data, failOnStatusCode: true })
+
+  async addModifier(...args: Parameters<typeof createModifier>) {
+    const res = await this.post(URI_MODIFIERS, createModifier(...args))
+    return (await res.json()) as Modifier
+  }
+
+  async addExercise(...args: Parameters<typeof createExercise>) {
+    const res = await this.post(URI_EXERCISES, createExercise(...args))
+    return (await res.json()) as Exercise
+  }
+
+  async addRecord(...args: Parameters<typeof createRecord>) {
+    const res = await this.post(URI_RECORDS, createRecord(...args))
+    return (await res.json()) as Record
+  }
+
+  // bodyweight uses an update schema with put given a date, not an add with post
+  async addBodyweight(...args: Parameters<typeof createBodyweight>) {
+    const bw = createBodyweight(...args)
+    const res = await this.request.put(URI_BODYWEIGHT + bw.date, {
+      data: bw,
+      failOnStatusCode: true,
+    })
+    return (await res.json()) as Bodyweight
+  }
+}

--- a/playwright/fixtures/index.ts
+++ b/playwright/fixtures/index.ts
@@ -2,6 +2,7 @@ import { test as baseTest } from '@playwright/test'
 import fs from 'fs'
 import { ObjectId } from 'mongodb'
 import path from 'path'
+import { Api } from './Api'
 
 /** Generates a userId from a unique number.
  *  The result is idempotent: the same number will
@@ -13,8 +14,18 @@ const getUserId = (uniqueNum: number) =>
 // This file is taken from the playwright docs.
 // See: https://playwright.dev/docs/auth#moderate-one-account-per-parallel-worker
 
+interface CustomFixtures {
+  /** Fixture that manipulates data by interacting with the rest api.
+   *  This gives faster results than clicking around in the ui.
+   */
+  api: Api
+}
+
 export * from '@playwright/test'
-export const test = baseTest.extend<object, { workerStorageState: string }>({
+export const test = baseTest.extend<
+  CustomFixtures,
+  { workerStorageState: string }
+>({
   // Use the same storage state for all tests in this worker.
   storageState: ({ workerStorageState }, apply) => apply(workerStorageState),
   // Authenticate once per worker with a worker-scoped fixture.
@@ -60,4 +71,5 @@ export const test = baseTest.extend<object, { workerStorageState: string }>({
     },
     { scope: 'worker' },
   ],
+  api: async ({ request }, apply) => apply(new Api(request)),
 })

--- a/playwright/sessions.test.ts
+++ b/playwright/sessions.test.ts
@@ -1,3 +1,6 @@
+import { URI_EXERCISES, URI_RECORDS } from '../lib/frontend/constants'
+import { createExercise } from '../models/AsyncSelectorOption/Exercise'
+import { createRecord } from '../models/Record'
 import { expect, test } from './fixtures'
 
 test('adds bodyweight', async ({ page }) => {
@@ -14,16 +17,24 @@ test('adds bodyweight', async ({ page }) => {
   await expect(page.getByText('Using latest official weight')).toBeVisible()
 })
 
-// todo: make 2 records and swap between the sessions
-test('loads calendar', async ({ page }) => {
-  await page.goto('/sessions/2000-01-01')
+test('loads calendar', async ({ page, request }) => {
+  const exercise = createExercise('squats')
+  const prevRecord = createRecord('2000-01-01', { exercise })
+  const curRecord = createRecord('2000-01-05', { exercise })
+  await request.post(URI_EXERCISES, { data: exercise })
+  await request.post(URI_RECORDS, { data: prevRecord })
+  await request.post(URI_RECORDS, { data: curRecord })
+  await page.goto('/sessions/2000-01-05')
 
   // open date picker -- have to specifically click the picker's label.
   // On desktop there is a distinct icon, but on mobile the whole input opens the picker.
-  await page.getByLabel('selected date is Jan 1').click()
+  await page.getByLabel('selected date is Jan 5').click()
 
-  // pick an arbitrary date to confirm the calendar is loaded
-  await expect(page.getByRole('gridcell', { name: '15' })).toBeVisible()
+  // confirm the populated sessions have badges
+  await expect(page.getByLabel('2000-01-01, Session data exists')).toBeVisible()
+  await expect(page.getByLabel('2000-01-05, Session data exists')).toBeVisible()
+  // and other dates do not
+  await expect(page.getByLabel('2000-01-22, No session data')).toBeVisible()
 })
 
 // The redirect is stored in local storage. This value is set in the settings

--- a/playwright/sessions.test.ts
+++ b/playwright/sessions.test.ts
@@ -1,6 +1,3 @@
-import { URI_EXERCISES, URI_RECORDS } from '../lib/frontend/constants'
-import { createExercise } from '../models/AsyncSelectorOption/Exercise'
-import { createRecord } from '../models/Record'
 import { expect, test } from './fixtures'
 
 test('adds bodyweight', async ({ page }) => {
@@ -17,13 +14,11 @@ test('adds bodyweight', async ({ page }) => {
   await expect(page.getByText('Using latest official weight')).toBeVisible()
 })
 
-test('loads calendar', async ({ page, request }) => {
-  const exercise = createExercise('squats')
-  const prevRecord = createRecord('2000-01-01', { exercise })
-  const curRecord = createRecord('2000-01-05', { exercise })
-  await request.post(URI_EXERCISES, { data: exercise })
-  await request.post(URI_RECORDS, { data: prevRecord })
-  await request.post(URI_RECORDS, { data: curRecord })
+test('loads calendar', async ({ page, api }) => {
+  const exercise = await api.addExercise('squats')
+  await api.addRecord('2000-01-01', { exercise })
+  await api.addRecord('2000-01-05', { exercise })
+
   await page.goto('/sessions/2000-01-05')
 
   // open date picker -- have to specifically click the picker's label.


### PR DESCRIPTION
Includes a fixture extension to post to the api to create db records instead of having to click around in the ui. 