### PR TITLE
Refactor date picker to have better UX

### DIFF
--- a/components/session/upper/BodyweightInputToggle.test.tsx
+++ b/components/session/upper/BodyweightInputToggle.test.tsx
@@ -40,7 +40,7 @@ it('switches type when same type clicked', async () => {
   )
 
   await user.click(screen.getByTestId('ScaleOutlinedIcon'))
-  await user.click(await screen.findByText('unofficial', { exact: false }))
+  await user.click(await screen.findByText(/unofficial/))
 
   expect(screen.queryByText('unofficial')).not.toBeInTheDocument()
   expect(handleTypeChange).toHaveBeenCalledTimes(1)

--- a/components/session/upper/SessionDatePicker.test.tsx
+++ b/components/session/upper/SessionDatePicker.test.tsx
@@ -6,7 +6,7 @@ import SessionDatePicker from './SessionDatePicker'
 
 const mockHandleDateChange = vi.fn()
 
-it('triggers date change when the new value is a valid date', async () => {
+it('updates date from keyboard input', async () => {
   const { user } = render(
     <SessionDatePicker
       day={dayjs('2020-01-02')}
@@ -14,15 +14,50 @@ it('triggers date change when the new value is a valid date', async () => {
     />
   )
 
-  await user.click(screen.getByRole('button', { name: 'Clear' }))
+  await user.click(screen.getByText('01'))
 
   // input day, month, and year separately
   await user.paste('03')
-  await user.paste('15')
-  await user.paste('2022')
+  await user.paste('09')
+  await user.paste('22')
 
-  // should only have called once, not three times
+  await user.keyboard('{Enter}')
+
   expect(mockHandleDateChange).toHaveBeenCalledTimes(1)
+})
+
+it('updates date from picker', async () => {
+  const { user } = render(
+    <SessionDatePicker
+      day={dayjs('2020-01-02')}
+      handleDayChange={mockHandleDateChange}
+    />
+  )
+
+  await user.click(screen.getByLabelText(/Choose date/))
+
+  // click a new day
+  await user.click(screen.getByText('15'))
+
+  // automatically submits
+  expect(mockHandleDateChange).toHaveBeenCalledTimes(1)
+})
+
+it('Shows correct aria label for picker button', async () => {
+  const { user } = render(
+    <SessionDatePicker
+      day={dayjs('2020-01-02')}
+      handleDayChange={mockHandleDateChange}
+    />
+  )
+
+  expect(screen.getByLabelText(/Jan 2, 2020/))
+
+  await user.click(screen.getByText('01'))
+  await user.keyboard('{Backspace}')
+
+  // exact label -- doesn't have a date
+  expect(screen.getByLabelText('Choose date'))
 })
 
 it('shows existing session data with badges', async () => {

--- a/components/session/upper/TitleBar.test.tsx
+++ b/components/session/upper/TitleBar.test.tsx
@@ -13,10 +13,12 @@ vi.mock('next/router', () => ({
 }))
 
 it('updates on date change', async () => {
-  const { user } = render(<TitleBar day={dayjs('2020-01-01')} />)
+  const { user } = render(<TitleBar day={dayjs('2020-01-05')} />)
 
-  await user.clear(screen.getByText('2020'))
-  await user.paste('2021')
+  // update the date
+  await user.click(screen.getByText('05'))
+  await user.paste('15')
+  await user.click(screen.getByLabelText('Confirm'))
 
-  expect(mocks.push).toHaveBeenCalledWith('2021-01-01')
+  expect(mocks.push).toHaveBeenCalledWith('2020-01-15')
 })

--- a/lib/frontend/constants.ts
+++ b/lib/frontend/constants.ts
@@ -1,6 +1,7 @@
 import { type CSSProperties } from '@mui/material/styles/createMixins'
 
 export const DATE_FORMAT = 'YYYY-MM-DD'
+export const DATE_PICKER_FORMAT = 'MM/DD/YY'
 export const TIME_FORMAT = 'HH:mm:ss'
 
 // Was thinking of making this a user pref, but may not be necessary.

--- a/playwright/navigation.test.ts
+++ b/playwright/navigation.test.ts
@@ -1,6 +1,6 @@
 import { test, expect } from './fixtures'
 import dayjs from 'dayjs'
-import { DATE_FORMAT } from '../lib/frontend/constants'
+import { DATE_FORMAT, DATE_PICKER_FORMAT } from '../lib/frontend/constants'
 
 test(`navigates to today's session from home page`, async ({ page }) => {
   await page.goto('/')
@@ -8,9 +8,9 @@ test(`navigates to today's session from home page`, async ({ page }) => {
 
   const today = dayjs()
 
-  // DatePicker input splits MM DD and YYYY into separate spans in the input,
+  // DatePicker input splits month, day, and year into separate spans in the input,
   // but getByText can combine them all together
-  await expect(page.getByText(today.format('MM/DD/YYYY'))).toBeVisible()
+  await expect(page.getByText(today.format(DATE_PICKER_FORMAT))).toBeVisible()
   // page.url() is synchronous. To wait for a url use page.waitForUrl().
   expect(page.url().includes(today.format(DATE_FORMAT)))
 })


### PR DESCRIPTION
- only use YY instead of YYYY
- add confirm button so it doesn't immediately change the day whenever you type
- add loading spinner when changing sessions