### PR TITLE
Tweak vitest settings

### DIFF
--- a/components/NavbarDrawer.test.tsx
+++ b/components/NavbarDrawer.test.tsx
@@ -1,3 +1,4 @@
+import { vi, it, expect } from 'vitest'
 import {
   devUserId,
   guestUserName,

--- a/components/Tooltip.test.tsx
+++ b/components/Tooltip.test.tsx
@@ -1,3 +1,4 @@
+import { it, expect, vi } from 'vitest'
 import { render, screen } from '../lib/testUtils'
 import Tooltip from './Tooltip'
 

--- a/components/TransitionIconButton.test.tsx
+++ b/components/TransitionIconButton.test.tsx
@@ -1,3 +1,4 @@
+import { it, expect } from 'vitest'
 import { render, screen } from '../lib/testUtils'
 import TransitionIconButton from './TransitionIconButton'
 

--- a/components/form-fields/AttributeCheckboxes.test.tsx
+++ b/components/form-fields/AttributeCheckboxes.test.tsx
@@ -1,3 +1,4 @@
+import { expect, it, vi } from 'vitest'
 import { render, screen } from '../../lib/testUtils'
 import { type Attributes } from '../../models/Attributes'
 import AttributeCheckboxes from './AttributeCheckboxes'

--- a/components/form-fields/ComboBoxField.test.tsx
+++ b/components/form-fields/ComboBoxField.test.tsx
@@ -1,3 +1,4 @@
+import { vi, it, expect } from 'vitest'
 import { render, screen } from '../../lib/testUtils'
 import ComboBoxField from './ComboBoxField'
 

--- a/components/form-fields/EquipmentWeightField.test.tsx
+++ b/components/form-fields/EquipmentWeightField.test.tsx
@@ -1,3 +1,4 @@
+import { vi, it, expect } from 'vitest'
 import { render, screen } from '../../lib/testUtils'
 import EquipmentWeightField from './EquipmentWeightField'
 

--- a/components/form-fields/InputField.test.tsx
+++ b/components/form-fields/InputField.test.tsx
@@ -1,6 +1,7 @@
 import { z } from 'zod'
 import { render, screen } from '../../lib/testUtils'
 import InputField from './InputField'
+import { vi, it, expect } from 'vitest'
 
 const mockHandleSubmit = vi.fn()
 

--- a/components/form-fields/NameField.test.tsx
+++ b/components/form-fields/NameField.test.tsx
@@ -1,3 +1,4 @@
+import { expect, it, vi } from 'vitest'
 import { render, screen } from '../../lib/testUtils'
 import NameField from './NameField'
 

--- a/components/form-fields/NotesList/AddNote.test.tsx
+++ b/components/form-fields/NotesList/AddNote.test.tsx
@@ -1,3 +1,4 @@
+import { vi, it, expect } from 'vitest'
 import { render, screen } from '../../../lib/testUtils'
 import AddNote from './AddNote'
 

--- a/components/form-fields/NotesList/NotesListItem.test.tsx
+++ b/components/form-fields/NotesList/NotesListItem.test.tsx
@@ -2,6 +2,7 @@ import { type ComponentProps } from 'react'
 import { render, screen } from '../../../lib/testUtils'
 import { createNote } from '../../../models/Note'
 import NotesListItem from './NotesListItem'
+import { vi, it, expect } from 'vitest'
 
 const mockHandleDelete = vi.fn()
 const mockUpdate = vi.fn()

--- a/components/form-fields/NotesList/TagChips.test.tsx
+++ b/components/form-fields/NotesList/TagChips.test.tsx
@@ -1,3 +1,4 @@
+import { it, expect } from 'vitest'
 import { render, screen } from '../../../lib/testUtils'
 import TagChips from './TagChips'
 

--- a/components/form-fields/NotesList/TagSelect.test.tsx
+++ b/components/form-fields/NotesList/TagSelect.test.tsx
@@ -1,3 +1,4 @@
+import { vi, it, expect } from 'vitest'
 import { render, screen } from '../../../lib/testUtils'
 import TagSelect from './TagSelect'
 

--- a/components/form-fields/NotesList/index.test.tsx
+++ b/components/form-fields/NotesList/index.test.tsx
@@ -1,3 +1,4 @@
+import { vi, it, expect } from 'vitest'
 import NotesList from '.'
 import { render, screen } from '../../../lib/testUtils'
 import { createNote } from '../../../models/Note'

--- a/components/form-fields/StatusSelectField.test.tsx
+++ b/components/form-fields/StatusSelectField.test.tsx
@@ -1,3 +1,4 @@
+import { vi, it, expect } from 'vitest'
 import { render, screen } from '../../lib/testUtils'
 import { Status } from '../../models/Status'
 import StatusSelectField from './StatusSelectField'

--- a/components/form-fields/UsageComboBox.test.tsx
+++ b/components/form-fields/UsageComboBox.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, useServer } from '../../lib/testUtils'
 import { createExercise } from '../../models/AsyncSelectorOption/Exercise'
 import UsageComboBox from './UsageComboBox'
 import * as restService from '../../lib/frontend/restService'
+import { it, vi, expect } from 'vitest'
 
 it('adds category to exercise', async () => {
   // spy must be inside the test

--- a/components/form-fields/actions/ActionItems.test.tsx
+++ b/components/form-fields/actions/ActionItems.test.tsx
@@ -1,6 +1,7 @@
 import { type ComponentProps } from 'react'
 import { render, screen, within } from '../../../lib/testUtils'
 import ActionItems from './ActionItems'
+import { vi, it, expect } from 'vitest'
 
 const mockHandleDelete = vi.fn()
 const mockHandleDuplicate = vi.fn()

--- a/components/form-fields/actions/DeleteButton.test.tsx
+++ b/components/form-fields/actions/DeleteButton.test.tsx
@@ -1,3 +1,4 @@
+import { vi, it, expect } from 'vitest'
 import { render, screen, waitFor, within } from '../../../lib/testUtils'
 import DeleteButton from './DeleteButton'
 

--- a/components/form-fields/actions/UsageButton.test.tsx
+++ b/components/form-fields/actions/UsageButton.test.tsx
@@ -1,3 +1,4 @@
+import { it, expect } from 'vitest'
 import { URI_RECORDS } from '../../../lib/frontend/constants'
 import { render, screen, useServer, waitFor } from '../../../lib/testUtils'
 import { createRecord } from '../../../models/Record'

--- a/components/form-fields/selectors/AsyncSelector.test.tsx
+++ b/components/form-fields/selectors/AsyncSelector.test.tsx
@@ -1,4 +1,4 @@
-import { vi } from 'vitest'
+import { expect, it, vi } from 'vitest'
 import { render, screen } from '../../../lib/testUtils'
 import {
   type AsyncSelectorOption,

--- a/components/form-fields/selectors/CategorySelector.test.tsx
+++ b/components/form-fields/selectors/CategorySelector.test.tsx
@@ -1,4 +1,4 @@
-import { vi } from 'vitest'
+import { expect, it, vi } from 'vitest'
 import { render, screen } from '../../../lib/testUtils'
 import CategorySelector from './CategorySelector'
 

--- a/components/form-fields/selectors/ExerciseSelector.test.tsx
+++ b/components/form-fields/selectors/ExerciseSelector.test.tsx
@@ -1,5 +1,5 @@
 import { type ComponentProps } from 'react'
-import { vi } from 'vitest'
+import { expect, it, vi } from 'vitest'
 import { URI_CATEGORIES } from '../../../lib/frontend/constants'
 import { render, screen, useServer } from '../../../lib/testUtils'
 import {

--- a/components/form-fields/selectors/ModifierSelector.test.tsx
+++ b/components/form-fields/selectors/ModifierSelector.test.tsx
@@ -1,4 +1,4 @@
-import { vi } from 'vitest'
+import { expect, it, vi } from 'vitest'
 import { render, screen } from '../../../lib/testUtils'
 import ModifierSelector from './ModifierSelector'
 

--- a/components/loading/RecordCardSkeleton.test.tsx
+++ b/components/loading/RecordCardSkeleton.test.tsx
@@ -1,3 +1,4 @@
+import { it, expect } from 'vitest'
 import { render, screen } from '../../lib/testUtils'
 import RecordCardSkeleton from './RecordCardSkeleton'
 

--- a/components/session/records/sets/AddSetButton.test.tsx
+++ b/components/session/records/sets/AddSetButton.test.tsx
@@ -1,4 +1,4 @@
-import { type MockInstance } from 'vitest'
+import { beforeEach, expect, it, vi, type MockInstance } from 'vitest'
 import * as restService from '../../../../lib/frontend/restService'
 import { render, screen } from '../../../../lib/testUtils'
 import { generateId } from '../../../../lib/util'

--- a/components/session/upper/BodyweightInput.test.tsx
+++ b/components/session/upper/BodyweightInput.test.tsx
@@ -3,6 +3,7 @@ import { URI_BODYWEIGHT } from '../../../lib/frontend/constants'
 import { render, screen, useServer } from '../../../lib/testUtils'
 import BodyweightInput from './BodyweightInput'
 import { createBodyweight } from '../../../models/Bodyweight'
+import { it, expect, describe } from 'vitest'
 
 const date2020 = dayjs('2020-01-01')
 const date2000 = dayjs('2000-01-01')

--- a/components/session/upper/BodyweightInputToggle.test.tsx
+++ b/components/session/upper/BodyweightInputToggle.test.tsx
@@ -1,4 +1,4 @@
-import { vi } from 'vitest'
+import { expect, it, vi } from 'vitest'
 import { render, screen, within } from '../../../lib/testUtils'
 import BodyweightInputToggle from './BodyweightInputToggle'
 

--- a/components/session/upper/RestTimer.test.tsx
+++ b/components/session/upper/RestTimer.test.tsx
@@ -1,5 +1,5 @@
 import dayjs, { type ManipulateType } from 'dayjs'
-import { beforeEach, vi } from 'vitest'
+import { afterAll, beforeAll, beforeEach, expect, it, vi } from 'vitest'
 import { act, render, screen } from '../../../lib/testUtils'
 import RestTimer from './RestTimer'
 

--- a/components/session/upper/SessionDatePicker.test.tsx
+++ b/components/session/upper/SessionDatePicker.test.tsx
@@ -1,5 +1,5 @@
 import dayjs from 'dayjs'
-import { vi } from 'vitest'
+import { expect, it, vi } from 'vitest'
 import { render, screen, useServer } from '../../../lib/testUtils'
 import { createSessionLog } from '../../../models/SessionLog'
 import SessionDatePicker from './SessionDatePicker'

--- a/components/session/upper/TitleBar.test.tsx
+++ b/components/session/upper/TitleBar.test.tsx
@@ -1,5 +1,5 @@
 import dayjs from 'dayjs'
-import { vi } from 'vitest'
+import { expect, it, vi } from 'vitest'
 import { render, screen } from '../../../lib/testUtils'
 import TitleBar from './TitleBar'
 

--- a/components/session/upper/WeightUnitConverter.test.tsx
+++ b/components/session/upper/WeightUnitConverter.test.tsx
@@ -1,3 +1,4 @@
+import { it, expect } from 'vitest'
 import { render, screen } from '../../../lib/testUtils'
 import WeightUnitConverter from './WeightUnitConverter'
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,5 +1,4 @@
 import { FlatCompat } from '@eslint/eslintrc'
-import vitest from '@vitest/eslint-plugin'
 import unusedImports from 'eslint-plugin-unused-imports'
 
 const compat = new FlatCompat({
@@ -8,11 +7,7 @@ const compat = new FlatCompat({
 })
 const eslintConfig = [
   {
-    plugins: { vitest, 'unused-imports': unusedImports },
-    rules: {
-      // no it.only
-      'vitest/no-focused-tests': 'error',
-    },
+    plugins: { 'unused-imports': unusedImports },
   },
   // nextjs rules are formatted using this FlatCompat setup
   ...compat.config({

--- a/lib/backend/apiMiddleware/withStatusHandler.test.ts
+++ b/lib/backend/apiMiddleware/withStatusHandler.test.ts
@@ -1,6 +1,6 @@
 import { StatusCodes } from 'http-status-codes'
 import { testApiHandler } from 'next-test-api-route-handler'
-import { vi } from 'vitest'
+import { beforeEach, expect, it, vi } from 'vitest'
 import { ZodError } from 'zod'
 import { ApiError } from '../../../models/ApiError'
 import { ERRORS } from '../../frontend/constants'

--- a/lib/frontend/useDisplayFields.test.ts
+++ b/lib/frontend/useDisplayFields.test.ts
@@ -7,6 +7,7 @@ import {
 } from '../../models/DisplayFields'
 import { DB_UNITS } from '../../models/Units'
 import useDisplayFields from './useDisplayFields'
+import { it, expect } from 'vitest'
 
 it('returns display fields from record', () => {
   const displayFields: DisplayFields = {

--- a/lib/testUtils.tsx
+++ b/lib/testUtils.tsx
@@ -12,19 +12,16 @@ import {
 } from 'next-test-api-route-handler'
 import { type ReactElement, type ReactNode } from 'react'
 import { SWRConfig } from 'swr'
-import { vi } from 'vitest'
 import { type ApiError } from '../models/ApiError'
 import { server } from '../msw-mocks/server'
 import { methodNotAllowed } from './backend/apiMiddleware/util'
 import { devUserId } from './frontend/constants'
 import { type Session } from 'next-auth'
+import { vi, expect } from 'vitest'
 
 // This file overwrites @testing-library's render and wraps it with components that
 // need to be set up for every test.
 
-// Any frontend component that uses SWR needs to be wrapped in SWRConfig to set the fetcher value.
-// Also, resetting provider resets the SWR cache between tests.
-// Components that don't use SWR can use the normal render.
 // Note: fetch() needs to be polyfilled or it will be undefined (just need to add "import 'whatwg-fetch'" in the test setup file).
 // See: https://testing-library.com/docs/react-testing-library/setup/#configuring-jest-with-test-utils
 // See: https://mswjs.io/docs/faq#swr

--- a/lib/util.test.ts
+++ b/lib/util.test.ts
@@ -6,6 +6,7 @@ import {
   generateId,
   removeUndefinedKeys,
 } from './util'
+import { it, describe, expect } from 'vitest'
 
 describe('validateId', () => {
   it('throws error when id format is invalid', () => {

--- a/models/ArrayMatchType.test.ts
+++ b/models/ArrayMatchType.test.ts
@@ -1,4 +1,5 @@
 import { ArrayMatchType, buildMatchTypeFilter } from './ArrayMatchType'
+import { it, expect } from 'vitest'
 
 it('builds standard MatchType', () => {
   expect(buildMatchTypeFilter(['hi'], ArrayMatchType.Exact)).toEqual({

--- a/models/AsyncSelectorOption/Exercise.test.ts
+++ b/models/AsyncSelectorOption/Exercise.test.ts
@@ -1,6 +1,7 @@
 import { type ParsedUrlQuery } from 'querystring'
 import { Status } from '../Status'
 import { exerciseQuerySchema } from './Exercise'
+import { it, expect } from 'vitest'
 
 it('transforms query params', () => {
   const apiQuery: ParsedUrlQuery = {

--- a/models/Record.test.ts
+++ b/models/Record.test.ts
@@ -1,6 +1,7 @@
 import { type ParsedUrlQuery } from 'querystring'
 import { ArrayMatchType } from './ArrayMatchType'
 import { recordQuerySchema } from './Record'
+import { it, expect } from 'vitest'
 
 it('transforms query params', () => {
   const apiQuery: ParsedUrlQuery = {

--- a/models/Set.test.ts
+++ b/models/Set.test.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest'
 import { calculateTotalValue, stringifySetType } from './Set'
 import { DB_UNITS } from './Units'
 

--- a/models/Units.test.ts
+++ b/models/Units.test.ts
@@ -1,4 +1,5 @@
 import { convertUnit } from './Units'
+import { it, describe, expect } from 'vitest'
 
 describe('convertUnit', () => {
   it('converts effort', () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,6 @@
         "@types/uuid": "^10.0.0",
         "@vitejs/plugin-react": "^4.4.1",
         "@vitest/coverage-v8": "^3.1.2",
-        "@vitest/eslint-plugin": "^1.1.44",
         "@vitest/ui": "^3.1.2",
         "cross-env": "^7.0.3",
         "eslint": "^9.25.1",
@@ -3077,26 +3076,6 @@
       },
       "peerDependenciesMeta": {
         "@vitest/browser": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@vitest/eslint-plugin": {
-      "version": "1.1.44",
-      "resolved": "https://registry.npmjs.org/@vitest/eslint-plugin/-/eslint-plugin-1.1.44.tgz",
-      "integrity": "sha512-m4XeohMT+Dj2RZfxnbiFR+Cv5dEC0H7C6TlxRQT7GK2556solm99kxgzJp/trKrZvanZcOFyw7aABykUTfWyrg==",
-      "dev": true,
-      "peerDependencies": {
-        "@typescript-eslint/utils": ">= 8.24.0",
-        "eslint": ">= 8.57.0",
-        "typescript": ">= 5.0.0",
-        "vitest": "*"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        },
-        "vitest": {
           "optional": true
         }
       }
@@ -12744,13 +12723,6 @@
         "test-exclude": "^7.0.1",
         "tinyrainbow": "^2.0.0"
       }
-    },
-    "@vitest/eslint-plugin": {
-      "version": "1.1.44",
-      "resolved": "https://registry.npmjs.org/@vitest/eslint-plugin/-/eslint-plugin-1.1.44.tgz",
-      "integrity": "sha512-m4XeohMT+Dj2RZfxnbiFR+Cv5dEC0H7C6TlxRQT7GK2556solm99kxgzJp/trKrZvanZcOFyw7aABykUTfWyrg==",
-      "dev": true,
-      "requires": {}
     },
     "@vitest/expect": {
       "version": "3.1.2",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "cg:phone": "npx playwright codegen --device \"iPhone 15 Pro Max\" localhost:7357",
     "cg:chrome": "npx playwright codegen --viewport-size \"1000,800\" localhost:7357",
     "test": "vitest --ui --open=false --hideSkippedTests",
-    "test:once": "vitest run --hideSkippedTests --allowOnly=false",
+    "test:once": "vitest run --allowOnly=false",
     "test:start": "vitest --ui --open=false --standalone",
     "db:dev": "npx vite-node scripts/mongoSeedDev.ts",
     "db:test": "npx vite-node scripts/mongoResetTest.ts",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "cg:phone": "npx playwright codegen --device \"iPhone 15 Pro Max\" localhost:7357",
     "cg:chrome": "npx playwright codegen --viewport-size \"1000,800\" localhost:7357",
     "test": "vitest --ui --open=false --hideSkippedTests",
-    "test:once": "vitest run --hideSkippedTests",
+    "test:once": "vitest run --hideSkippedTests --allowOnly=false",
+    "test:start": "vitest --ui --open=false --standalone",
     "db:dev": "npx vite-node scripts/mongoSeedDev.ts",
     "db:test": "npx vite-node scripts/mongoResetTest.ts",
     "knip": "knip"
@@ -57,7 +58,6 @@
     "@types/uuid": "^10.0.0",
     "@vitejs/plugin-react": "^4.4.1",
     "@vitest/coverage-v8": "^3.1.2",
-    "@vitest/eslint-plugin": "^1.1.44",
     "@vitest/ui": "^3.1.2",
     "cross-env": "^7.0.3",
     "eslint": "^9.25.1",

--- a/pages/api/auth/[...nextauth].test.ts
+++ b/pages/api/auth/[...nextauth].test.ts
@@ -2,6 +2,7 @@ import { type Session } from 'next-auth/core/types'
 import { type JWT } from 'next-auth/jwt'
 import { devUserId } from '../../../lib/frontend/constants'
 import { authOptions } from './[...nextauth].api'
+import { vi, it, expect } from 'vitest'
 
 // provider options are typed as "any", so we can't avoid the eslint warnings
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */

--- a/pages/api/bodyweights/[date].test.ts
+++ b/pages/api/bodyweights/[date].test.ts
@@ -1,4 +1,4 @@
-import { vi } from 'vitest'
+import { vi, it } from 'vitest'
 import { updateBodyweight } from '../../../lib/backend/mongoService'
 import {
   expectApiErrorsOnInvalidMethod,

--- a/pages/api/bodyweights/index.test.ts
+++ b/pages/api/bodyweights/index.test.ts
@@ -1,4 +1,4 @@
-import { vi } from 'vitest'
+import { vi, it } from 'vitest'
 import { fetchBodyweights } from '../../../lib/backend/mongoService'
 import {
   expectApiErrorsOnInvalidMethod,

--- a/pages/api/categories/[id].test.ts
+++ b/pages/api/categories/[id].test.ts
@@ -1,4 +1,4 @@
-import { vi } from 'vitest'
+import { vi, it } from 'vitest'
 import {
   deleteCategory,
   fetchCategory,

--- a/pages/api/categories/index.test.ts
+++ b/pages/api/categories/index.test.ts
@@ -1,4 +1,4 @@
-import { vi } from 'vitest'
+import { vi, it } from 'vitest'
 import { addCategory, fetchCategories } from '../../../lib/backend/mongoService'
 import {
   expectApiErrorsOnInvalidMethod,

--- a/pages/api/exercises/[id].test.ts
+++ b/pages/api/exercises/[id].test.ts
@@ -1,4 +1,4 @@
-import { vi } from 'vitest'
+import { vi, it } from 'vitest'
 import {
   deleteExercise,
   fetchExercise,

--- a/pages/api/exercises/index.test.ts
+++ b/pages/api/exercises/index.test.ts
@@ -1,4 +1,4 @@
-import { vi } from 'vitest'
+import { vi, it } from 'vitest'
 import { addExercise, fetchExercises } from '../../../lib/backend/mongoService'
 import {
   expectApiErrorsOnInvalidMethod,

--- a/pages/api/modifiers/[id].test.ts
+++ b/pages/api/modifiers/[id].test.ts
@@ -1,4 +1,4 @@
-import { vi } from 'vitest'
+import { vi, it } from 'vitest'
 import {
   deleteModifier,
   fetchModifier,

--- a/pages/api/modifiers/index.test.ts
+++ b/pages/api/modifiers/index.test.ts
@@ -1,4 +1,4 @@
-import { vi } from 'vitest'
+import { vi, it } from 'vitest'
 import { addModifier, fetchModifiers } from '../../../lib/backend/mongoService'
 import {
   expectApiErrorsOnInvalidMethod,

--- a/pages/api/records/[id].test.ts
+++ b/pages/api/records/[id].test.ts
@@ -1,4 +1,3 @@
-import { vi } from 'vitest'
 import {
   deleteRecord,
   fetchRecord,
@@ -12,6 +11,7 @@ import {
 import { generateId } from '../../../lib/util'
 import handler from './[id].api'
 import { createRecord } from '../../../models/Record'
+import { vi, it } from 'vitest'
 
 export const data = createRecord('2000-01-01')
 const id = generateId()

--- a/pages/api/records/index.test.ts
+++ b/pages/api/records/index.test.ts
@@ -1,4 +1,3 @@
-import { vi } from 'vitest'
 import { addRecord, fetchRecords } from '../../../lib/backend/mongoService'
 import {
   expectApiErrorsOnInvalidMethod,
@@ -6,6 +5,7 @@ import {
 } from '../../../lib/testUtils'
 import handler from './index.api'
 import { createRecord } from '../../../models/Record'
+import { vi, it } from 'vitest'
 
 it('fetches records', async () => {
   const data = [createRecord('2000-01-01')]

--- a/pages/api/sessions/[date].test.ts
+++ b/pages/api/sessions/[date].test.ts
@@ -1,4 +1,4 @@
-import { vi } from 'vitest'
+import { vi, it } from 'vitest'
 import { fetchSession, updateSession } from '../../../lib/backend/mongoService'
 import {
   expectApiErrorsOnInvalidMethod,

--- a/pages/api/sessions/index.test.ts
+++ b/pages/api/sessions/index.test.ts
@@ -1,4 +1,4 @@
-import { vi } from 'vitest'
+import { vi, it } from 'vitest'
 import { fetchSessions } from '../../../lib/backend/mongoService'
 import {
   expectApiErrorsOnInvalidMethod,

--- a/pages/index.test.tsx
+++ b/pages/index.test.tsx
@@ -1,5 +1,6 @@
 import Home from '../pages/index.page'
 import { render, screen } from '../lib/testUtils'
+import { expect, it } from 'vitest'
 
 // testing links / routing should be done at the e2e level
 it('renders', async () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,18 +1,10 @@
 {
   "compilerOptions": {
     "target": "es2017",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     // node_modules has to be a typeRoot for vite/client.
     // See: https://github.com/microsoft/TypeScript/issues/54629#issuecomment-1589593147
-    "typeRoots": [
-      "./types",
-      "./node_modules/@types",
-      "./node_modules"
-    ],
+    "typeRoots": ["./types", "./node_modules/@types", "./node_modules"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -24,10 +16,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
-    "types": [
-      "vite/client",
-      "vitest/globals"
-    ],
+    "types": ["vite/client"],
     "incremental": true,
     "plugins": [
       {
@@ -42,7 +31,5 @@
     "next-env.d.ts",
     ".next/types/**/*.ts"
   ],
-  "exclude": [
-    "node_modules"
-  ]
+  "exclude": ["node_modules"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,18 @@
 {
   "compilerOptions": {
     "target": "es2017",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     // node_modules has to be a typeRoot for vite/client.
     // See: https://github.com/microsoft/TypeScript/issues/54629#issuecomment-1589593147
-    "typeRoots": ["./types", "./node_modules/@types", "./node_modules"],
+    "typeRoots": [
+      "./types",
+      "./node_modules/@types",
+      "./node_modules"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -16,11 +24,25 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
-    "types": ["vite/client", "vitest/globals"],
-    "incremental": true
+    "types": [
+      "vite/client",
+      "vitest/globals"
+    ],
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "eslint.config.js"],
+  "include": [
+    "**/*.ts",
+    "**/*.tsx",
+    "eslint.config.js",
+    "next-env.d.ts",
+    ".next/types/**/*.ts"
+  ],
   "exclude": [
-    "node_modules",
+    "node_modules"
   ]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,18 +7,7 @@ export default defineConfig({
   plugins: [react(), tsconfigPaths()],
   test: {
     exclude: ['playwright', 'node_modules'],
-    coverage: {
-      // json reporters are needed for github action summary report
-      reporter: ['text-summary', 'html', 'json-summary', 'json'],
-      all: true,
-      enabled: true,
-      include: ['components', 'lib', 'pages', 'models'],
-      // thresholdAutoUpdate: true,
-      // branches: 77.48,
-      // functions: 45.13,
-      // lines: 31.5,
-      // statements: 31.5,
-    },
+    bail: process.env.CI ? 1 : 0,
     // Unlike jest, vitest has the option to not globally import describe/it etc keywords.
     // This is desireable to avoid conflicts with other testing libraries we may use (eg e2e tests).
     // However, disabling this causes two major issues with no easily traceable cause or solution:
@@ -26,13 +15,21 @@ export default defineConfig({
     // - tests start failing because apparently server.resetHandlers() stops being called before each test for unknown reasons
     // In light of these issues we've opted to keep globals enabled.
     globals: true,
-    // happy-dom? Supposed to be faster, but seems to not work well with mui components
     environment: 'jsdom',
-    // environmentMatchGlobs: [
-    //   ['*.tsx', 'jsdom'],
-    //   ['*.ts', 'node'],
-    // ],
     setupFiles: 'vitest.setup.ts',
+    // clear mock history, restore each implementation to its original, and restore original descriptors of spied-on objects
     restoreMocks: true,
+    coverage: {
+      // enable coverage
+      enabled: true,
+      // json reporters are needed for github action summary report
+      reporter: ['text-summary', 'html', 'json-summary', 'json'],
+      include: ['components', 'lib', 'pages', 'models'],
+      // thresholdAutoUpdate: true,
+      // branches: 77.48,
+      // functions: 45.13,
+      // lines: 31.5,
+      // statements: 31.5,
+    },
   },
 })

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,13 +8,6 @@ export default defineConfig({
   test: {
     exclude: ['playwright', 'node_modules'],
     bail: process.env.CI ? 1 : 0,
-    // Unlike jest, vitest has the option to not globally import describe/it etc keywords.
-    // This is desireable to avoid conflicts with other testing libraries we may use (eg e2e tests).
-    // However, disabling this causes two major issues with no easily traceable cause or solution:
-    // - vscode can only sometimes detect vitest package to auto import keywords, so you have to manually type in imports
-    // - tests start failing because apparently server.resetHandlers() stops being called before each test for unknown reasons
-    // In light of these issues we've opted to keep globals enabled.
-    globals: true,
     environment: 'jsdom',
     setupFiles: 'vitest.setup.ts',
     // clear mock history, restore each implementation to its original, and restore original descriptors of spied-on objects

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom/vitest'
-import { configure } from '@testing-library/react'
+import { cleanup, configure } from '@testing-library/react'
 import { server } from './msw-mocks/server'
-import { vi } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, vi } from 'vitest'
 import 'whatwg-fetch'
 import { devUserId } from './lib/frontend/constants'
 
@@ -52,4 +52,7 @@ beforeAll(() => {
   globalThis.jest = vi
 })
 beforeEach(() => server.resetHandlers())
+// RTL cleanup is only automatically called if vitest has globals on.
+// Without this, the DOM will leak between tests.
+afterEach(() => cleanup())
 afterAll(() => server.close())


### PR DESCRIPTION
includes big change of removing global, so vitest functions must be imported in the files that use them instead of being globally available