### PR TITLE
consolidate all layout wrappers to layout component

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -8,34 +8,76 @@ import AppSnackbar from './AppSnackbar'
 import { Analytics } from '@vercel/analytics/next'
 import Container from '@mui/material/Container'
 import { createTheme, ThemeProvider } from '@mui/material/styles'
+import { SessionProvider } from 'next-auth/react'
+import { SWRConfig, type SWRConfiguration } from 'swr'
+import useSWRCacheProvider from '../components/useSWRCacheProvider'
+import { swrFetcher } from '../lib/util'
+import { useEffect } from 'react'
+import { NuqsAdapter } from 'nuqs/adapters/next/pages'
+import { type Session } from 'next-auth'
 
-export default function Layout({ children }: { children: ReactNode }) {
+const disableNumberSpin = () => {
+  if (!(document.activeElement instanceof HTMLInputElement)) return
+
+  if (document.activeElement.type === 'number') {
+    document.activeElement.blur()
+  }
+}
+
+interface Props {
+  children: ReactNode
+  swrConfig?: SWRConfiguration
+  /** only needs to be provided if mocking the user */
+  session?: Session
+  /** navbar should be disabled for component testing */
+  disableNavbar?: boolean
+}
+export default function Layout({
+  children,
+  swrConfig,
+  session,
+  disableNavbar,
+}: Props) {
   const theme = createTheme({
     palette: { ...bluePalette },
   })
+  const provider = useSWRCacheProvider()
+
+  // disable any numeric fields from having the "scroll to increment value" feature
+  useEffect(() => {
+    document.addEventListener('wheel', disableNumberSpin)
+
+    return () => document.removeEventListener('wheel', disableNumberSpin)
+  }, [])
 
   return (
-    <ThemeProvider theme={theme}>
-      <LocalizationProvider dateAdapter={AdapterDayjs}>
-        <SnackbarProvider
-          maxSnack={1}
-          // notistack requires you to assign a snackbar to each variant.
-          // This means we would have to assign the same snackbar to each key
-          // (success, error, etc). Instead we override the default variant,
-          // turn off all other variants, and add a "severity" prop.
-          // See notistack.d.ts for type definitions
-          Components={{
-            default: AppSnackbar,
-          }}
-          anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
-        >
-          <Analytics />
-          <Navbar />
-          <main>
-            <Container maxWidth="lg">{children}</Container>
-          </main>
-        </SnackbarProvider>
-      </LocalizationProvider>
-    </ThemeProvider>
+    <SessionProvider session={session}>
+      <SWRConfig value={swrConfig ?? { fetcher: swrFetcher, provider }}>
+        <NuqsAdapter>
+          <ThemeProvider theme={theme}>
+            <LocalizationProvider dateAdapter={AdapterDayjs}>
+              <SnackbarProvider
+                maxSnack={1}
+                // notistack requires you to assign a snackbar to each variant.
+                // This means we would have to assign the same snackbar to each key
+                // (success, error, etc). Instead we override the default variant,
+                // turn off all other variants, and add a "severity" prop.
+                // See notistack.d.ts for type definitions
+                Components={{
+                  default: AppSnackbar,
+                }}
+                anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+              >
+                <Analytics />
+                {!disableNavbar && <Navbar />}
+                <main>
+                  <Container maxWidth="lg">{children}</Container>
+                </main>
+              </SnackbarProvider>
+            </LocalizationProvider>
+          </ThemeProvider>
+        </NuqsAdapter>
+      </SWRConfig>
+    </SessionProvider>
   )
 }

--- a/pages/_app.page.tsx
+++ b/pages/_app.page.tsx
@@ -1,42 +1,12 @@
-import { SessionProvider } from 'next-auth/react'
 import type { AppProps } from 'next/app'
-import '../styles/globals.css'
-import { SWRConfig } from 'swr'
 import Layout from '../components/Layout'
-import useSWRCacheProvider from '../components/useSWRCacheProvider'
-import { swrFetcher } from '../lib/util'
-import { useEffect } from 'react'
-import { NuqsAdapter } from 'nuqs/adapters/next/pages'
+// global styles must be imported from this file
+import '../styles/globals.css'
 
-const disableNumberSpin = () => {
-  if (!(document.activeElement instanceof HTMLInputElement)) return
-
-  if (document.activeElement.type === 'number') {
-    document.activeElement.blur()
-  }
-}
-
-function IronLog({ Component, pageProps }: AppProps) {
-  const provider = useSWRCacheProvider()
-
-  // disable any numeric fields from having the "scroll to increment value" feature
-  useEffect(() => {
-    document.addEventListener('wheel', disableNumberSpin)
-
-    return () => document.removeEventListener('wheel', disableNumberSpin)
-  }, [])
-
+export default function IronLog({ Component, pageProps }: AppProps) {
   return (
-    <SessionProvider>
-      <SWRConfig value={{ fetcher: swrFetcher, provider }}>
-        <NuqsAdapter>
-          <Layout>
-            <Component {...pageProps} />
-          </Layout>
-        </NuqsAdapter>
-      </SWRConfig>
-    </SessionProvider>
+    <Layout>
+      <Component {...pageProps} />
+    </Layout>
   )
 }
-
-export default IronLog


### PR DESCRIPTION
Moves some wrappers that had been in `_app.page.tsx` to `Layout.tsx`. Also uses the `Layout` component in vitest instead of a custom testing layout.