### PR TITLE
add interval timer; remove pause from rest timer

### DIFF
--- a/components/session/upper/IntervalSettingsDialog.test.tsx
+++ b/components/session/upper/IntervalSettingsDialog.test.tsx
@@ -1,0 +1,83 @@
+import { beforeEach, expect, it, vi } from 'vitest'
+import { LOCAL_STORAGE } from '../../../lib/frontend/constants'
+import { render, screen } from '../../../lib/test/rtl'
+import IntervalSettingsDialog from './IntervalSettingsDialog'
+
+const mockSubmit = vi.fn()
+
+const TestWrapper = () => {
+  return (
+    <IntervalSettingsDialog
+      open={true}
+      setOpen={vi.fn()}
+      handleSubmit={mockSubmit}
+    />
+  )
+}
+
+beforeEach(() => {
+  localStorage.clear()
+})
+
+it('submits valid changes', async () => {
+  const { user } = render(<TestWrapper />)
+
+  await user.type(screen.getByLabelText('Delay'), '5')
+  await user.type(screen.getByLabelText('Work'), '3')
+  await user.type(screen.getByLabelText('Rest'), '7')
+  await user.click(screen.getByText('Confirm'))
+
+  expect(mockSubmit).toHaveBeenCalledWith({ delay: 5, work: 3, rest: 7 })
+})
+
+it('cancels', async () => {
+  const { user } = render(<TestWrapper />)
+
+  await user.click(screen.getByText('Cancel'))
+
+  expect(mockSubmit).not.toHaveBeenCalled()
+})
+
+it('defaults to minimum values if provided invalid values', async () => {
+  const { user } = render(<TestWrapper />)
+
+  await user.type(screen.getByLabelText('Delay'), 'x')
+  await user.type(screen.getByLabelText('Work'), '-3')
+  await user.type(screen.getByLabelText('Rest'), '0')
+  await user.click(screen.getByText('Confirm'))
+
+  expect(mockSubmit).toHaveBeenCalledWith({ delay: 0, work: 1, rest: 1 })
+})
+
+it('defaults to minimum values if provided no values', async () => {
+  const { user } = render(<TestWrapper />)
+
+  await user.click(screen.getByText('Confirm'))
+
+  expect(mockSubmit).toHaveBeenCalledWith({ delay: 0, work: 1, rest: 1 })
+})
+
+it('uses values from local storage', async () => {
+  localStorage.setItem(
+    LOCAL_STORAGE.intervalTimer,
+    JSON.stringify({ delay: 3, work: 10, rest: 15 })
+  )
+  render(<TestWrapper />)
+
+  expect(screen.getByDisplayValue('3')).toBeVisible()
+  expect(screen.getByDisplayValue('10')).toBeVisible()
+  expect(screen.getByDisplayValue('15')).toBeVisible()
+})
+
+it('does not show zero if input is cleared', async () => {
+  localStorage.setItem(
+    LOCAL_STORAGE.intervalTimer,
+    JSON.stringify({ delay: 3 })
+  )
+  const { user } = render(<TestWrapper />)
+
+  await user.clear(screen.getByDisplayValue('3'))
+
+  expect(screen.queryByDisplayValue('0')).not.toBeInTheDocument()
+  expect(screen.getAllByDisplayValue('').length).toBe(3)
+})

--- a/components/session/upper/IntervalSettingsDialog.tsx
+++ b/components/session/upper/IntervalSettingsDialog.tsx
@@ -1,0 +1,120 @@
+import Button from '@mui/material/Button'
+import Dialog from '@mui/material/Dialog'
+import DialogActions from '@mui/material/DialogActions'
+import DialogContent from '@mui/material/DialogContent'
+import DialogTitle from '@mui/material/DialogTitle'
+import Stack from '@mui/material/Stack'
+import TextField from '@mui/material/TextField'
+import { useState } from 'react'
+import useLocalStorageState from 'use-local-storage-state'
+import { LOCAL_STORAGE } from '../../../lib/frontend/constants'
+import type { IntervalSettings } from './RestTimer'
+
+interface Props {
+  open: boolean
+  setOpen: (open: boolean) => void
+  handleSubmit: (settings: IntervalSettings) => void
+}
+export default function IntervalSettingsDialog({
+  open,
+  setOpen,
+  handleSubmit,
+}: Props) {
+  const [stored, setStored] = useLocalStorageState<IntervalSettings>(
+    LOCAL_STORAGE.intervalTimer
+  )
+  const [dirty, setDirty] = useState<Partial<IntervalSettings>>(stored ?? {})
+
+  const updateDirty = (changes: Partial<typeof dirty>) => {
+    setDirty((prev) => ({ ...prev, ...changes }))
+  }
+
+  const saveStored = () => {
+    const newSettings = {
+      delay: Math.max(dirty.delay ?? 0, 0),
+      work: Math.max(dirty.work ?? 0, 1),
+      rest: Math.max(dirty.rest ?? 0, 1),
+    }
+
+    handleClose()
+    setStored(newSettings)
+    handleSubmit(newSettings)
+  }
+
+  const handleClose = () => setOpen(false)
+
+  return (
+    <Dialog open={open} onClose={handleClose}>
+      <DialogTitle>Interval settings</DialogTitle>
+      <DialogContent>
+        <Stack spacing={2} pt={2}>
+          <SettingsField
+            label="Delay"
+            value={dirty.delay}
+            handleChange={(delay) => updateDirty({ delay })}
+            helperText="Delay before first work set. Can be zero."
+            placeholder="0"
+          />
+          <SettingsField
+            label="Work"
+            value={dirty.work}
+            handleChange={(work) => updateDirty({ work })}
+            helperText="Time given for each working rep."
+            placeholder="1"
+          />
+          <SettingsField
+            label="Rest"
+            value={dirty.rest}
+            handleChange={(rest) => updateDirty({ rest })}
+            helperText="Rest time between each working rep."
+            placeholder="1"
+          />
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleClose}>Cancel</Button>
+        <Button onClick={saveStored}>Confirm</Button>
+      </DialogActions>
+    </Dialog>
+  )
+}
+
+interface SettingsFieldProps {
+  label: string
+  value?: number
+  handleChange: (value?: number) => void
+  helperText: string
+  placeholder: string
+}
+const SettingsField = ({
+  label,
+  value,
+  handleChange,
+  helperText,
+  placeholder,
+}: SettingsFieldProps) => {
+  return (
+    <TextField
+      label={label}
+      value={value ?? ''}
+      onChange={(e) =>
+        handleChange(e.target.value ? +e.target.value : undefined)
+      }
+      helperText={helperText}
+      placeholder={placeholder}
+      onFocus={(e) => e.target.select()}
+      slotProps={{
+        input: {
+          endAdornment: 'sec',
+        },
+        inputLabel: {
+          shrink: true,
+        },
+        htmlInput: {
+          inputMode: 'decimal',
+          type: 'number',
+        },
+      }}
+    />
+  )
+}

--- a/components/session/upper/useClockReducer.ts
+++ b/components/session/upper/useClockReducer.ts
@@ -1,0 +1,74 @@
+import dayjs from 'dayjs'
+import { useReducer } from 'react'
+
+interface State {
+  enabled: boolean
+  isRunning: boolean
+  /** When the session is marked as finished the timer will show the total session time. */
+  isFinished: boolean
+  /** Value displayed, in ms */
+  displayValue: number
+  /** When the timer was initially started. Used to calculate total time. Total time cannot be paused or reset. */
+  startTime: number
+  /** When the timer was started / resumed. Note: pause/resume has been removed. */
+  resumeTime: number
+  /** Delta time between current and resume time is added here when timer is paused */
+  accumulatedTime: number
+}
+
+interface Action {
+  type: 'start' | 'stop' | 'reset' | 'tick' | 'finish'
+}
+
+const initialTimerState: State = {
+  enabled: false,
+  isRunning: false,
+  isFinished: false,
+  startTime: 0,
+  resumeTime: 0,
+  displayValue: 0,
+  accumulatedTime: 0,
+}
+
+// this is essentially a stopwatch with limited functionality (we probably don't want/need a full stopwatch here)
+function clockReducer(state: State, action: Action): State {
+  const now = dayjs().valueOf()
+  const deltaTime = state.isRunning ? now - state.resumeTime : 0
+  switch (action.type) {
+    case 'start':
+      return {
+        ...state,
+        startTime: now,
+        resumeTime: now,
+        isRunning: true,
+        enabled: true,
+      }
+    case 'stop':
+      return initialTimerState
+    case 'finish':
+      return {
+        ...state,
+        isRunning: false,
+        isFinished: true,
+        displayValue: now - state.startTime,
+      }
+    case 'reset':
+      return {
+        ...state,
+        resumeTime: dayjs().valueOf(),
+        isRunning: true,
+        accumulatedTime: 0,
+        displayValue: 0,
+        isFinished: false,
+      }
+    case 'tick':
+      return {
+        ...state,
+        displayValue: deltaTime + state.accumulatedTime,
+      }
+  }
+}
+
+export default function useClockReducer() {
+  return useReducer(clockReducer, initialTimerState)
+}

--- a/lib/frontend/constants.ts
+++ b/lib/frontend/constants.ts
@@ -33,6 +33,7 @@ export enum QUERY_KEYS {
 export enum LOCAL_STORAGE {
   sessionRedirect = 'sessionRedirect',
   showSaving = 'showSaving',
+  intervalTimer = 'intervalTimer',
 }
 
 // Fun fact: after naming this, found out mui date picker internals has an identical function.


### PR DESCRIPTION
interval timer is integrated into rest timer for sets that have a set work/rest time (typically for grip strength: a rep could be something like "hold weight for 5 sec, rest for 10 sec")

Removed pause/resume functionality from rest timer. There shouldn't be a reason to ever pause it. It's not a normal stopwatch. The interval timer added another button and with the pause button it looked like too many buttons.