### PR TITLE
reuse similar querykey; investigate syncing across tabs

### DIFF
--- a/components/form-fields/actions/UsageButton.tsx
+++ b/components/form-fields/actions/UsageButton.tsx
@@ -17,7 +17,7 @@ import { stringifySetType } from '../../../models/Set'
 import LoadingSpinner from '../../loading/LoadingSpinner'
 import TooltipIconButton from '../../TooltipIconButton'
 
-const maxRecords = 10
+export const usageLimit = 11
 
 interface Props {
   exercise?: string
@@ -31,7 +31,7 @@ export default function UsageButton({ exercise, type, buttonProps }: Props) {
   const { data: records, isLoading } = useRecords(
     {
       exercise,
-      limit: maxRecords + 1,
+      limit: usageLimit,
     },
     !!exercise && (open || type === 'text')
   )
@@ -44,7 +44,7 @@ export default function UsageButton({ exercise, type, buttonProps }: Props) {
           startIcon={
             <Badge
               badgeContent={records?.length}
-              max={maxRecords}
+              max={usageLimit}
               color="primary"
               aria-label={`used in ${records?.length ?? 0} record${records?.length !== 1 ? 's' : ''}`}
             >
@@ -75,7 +75,7 @@ export default function UsageButton({ exercise, type, buttonProps }: Props) {
           ) : (
             <List disablePadding>
               {records
-                .slice(0, maxRecords)
+                .slice(0, usageLimit)
                 .map(({ date, setType, sets, exercise, _id }) => (
                   // Note: this is Nextjs Link, not mui
                   <Link key={_id} href={`/sessions/${date}?record=${_id}`}>

--- a/components/forms/ExerciseForm.tsx
+++ b/components/forms/ExerciseForm.tsx
@@ -24,6 +24,7 @@ import {
 import type { Note } from '../../models/Note'
 import AttributeCheckboxes from '../form-fields/AttributeCheckboxes'
 import ActionItems from '../form-fields/actions/ActionItems'
+import { usageLimit } from '../form-fields/actions/UsageButton'
 import ComboBoxField from '../form-fields/ComboBoxField'
 import EquipmentWeightField from '../form-fields/EquipmentWeightField'
 import NameField from '../form-fields/NameField'
@@ -37,7 +38,9 @@ export default function ExerciseForm({ exercise }: Props) {
   const { _id, name, status, notes, attributes, weight } = exercise
   const modifiers = useModifiers()
   const categories = useCategories()
-  const { data: records } = useRecords({ exercise: name })
+  // Match the query from UsageButton to reuse the same key.
+  // This is only used in this component to determine if "delete" is disabled.
+  const { data: records } = useRecords({ exercise: name, limit: usageLimit })
   const exercises = useExercises()
   const [_, setUrlExercise] = useQueryState('exercise')
   const addExerciseMutate = useAddMutation({


### PR DESCRIPTION
mainly was investigating how to sync across tab so if "manage" was open and in another tab an exercise was added / removed the manage page would update the delete button. BUT it turns out tanstack does not sync across tabs. There is an extra experimental lib you can add to enable that (broadcast). Will not add at this time since that's not a big concern. Typical use is in a single tab, and if you make a mutation on an outdated cache there will just be an error saying to reload