### PR TITLE
fix equipment weight not saving as null

### DIFF
--- a/components/form-fields/EquipmentWeightField.test.tsx
+++ b/components/form-fields/EquipmentWeightField.test.tsx
@@ -21,6 +21,23 @@ it('calls update handler', async () => {
   expect(mockHandleUpdate).toHaveBeenCalledWith({ weight: 5 })
 })
 
+it('clears out existing weight', async () => {
+  const { user } = render(
+    <>
+      <div>other</div>
+      <EquipmentWeightField handleUpdate={mockHandleUpdate} weight={5} />
+    </>
+  )
+
+  await user.clear(screen.getByDisplayValue('5'))
+  // trigger save on blur
+  await user.click(screen.getByText('other'))
+
+  // this cannot be called with "undefined" because it gets jsonified when being
+  // passed to the backend, which strips undefined values
+  expect(mockHandleUpdate).toHaveBeenCalledWith({ weight: null })
+})
+
 it('handles changing units', async () => {
   DEFAULT_DISPLAY_FIELDS.units = { ...DB_UNITS, weight: 'lbs' }
   const { user } = render(

--- a/components/form-fields/EquipmentWeightField.tsx
+++ b/components/form-fields/EquipmentWeightField.tsx
@@ -24,7 +24,12 @@ export default function EquipmentWeightField({ weight, handleUpdate }: Props) {
       handleSubmit={useCallback(
         (weight) => {
           handleUpdate({
-            weight: convertUnit(weight, 'weight', weightUnit, DB_UNITS.weight),
+            weight: convertUnit(
+              weight ?? null,
+              'weight',
+              weightUnit,
+              DB_UNITS.weight
+            ),
           })
         },
         [handleUpdate, weightUnit]

--- a/components/session/upper/WeightUnitConverter.tsx
+++ b/components/session/upper/WeightUnitConverter.tsx
@@ -10,7 +10,7 @@ import { convertUnit } from '../../../models/Units'
 export default function WeightUnitConverter() {
   // the Textfield's value is a string, but it's based off kg here which is a number.
   // We need to make sure any cases of undefined in value/onChange get mapped to an empty string.
-  const [kg, setKg] = useState<number>()
+  const [kg, setKg] = useState<number | null>()
 
   return (
     <Stack direction="row" sx={{ justifyContent: 'center' }}>

--- a/models/Units.ts
+++ b/models/Units.ts
@@ -46,7 +46,7 @@ export const FACTORS = {
 
 /** Convert a unit from source to dest type. */
 export function convertUnit<Dimension extends keyof Units>(
-  value: number | undefined,
+  value: number | undefined | null,
   dimension: Dimension,
   source: Units[Dimension],
   dest: Units[Dimension],
@@ -55,7 +55,7 @@ export function convertUnit<Dimension extends keyof Units>(
   extraValue = 0,
   /** number of decimals to round to */
   roundedDecimals?: number
-): number | undefined {
+): number | undefined | null {
   // we want to show extraValue if it exists and value is undefined
   if (!value && !extraValue) return value // value could be 0 or undefined
 


### PR DESCRIPTION
it was passing "undefined" to the server function, which was being stripped from the json passed to the server. This means when it was being updated to undefined (removing the value), it was doing nothing. Instead, it should be null.