### PR TITLE
simplify records to use exercise id string

### DIFF
--- a/app/history/page.tsx
+++ b/app/history/page.tsx
@@ -41,7 +41,7 @@ export default function HistoryPage() {
       <Box pt={2}>
         <StyledDivider />
       </Box>
-      {query?.exercise && (
+      {query?.exerciseId && (
         <HistoryCardsSwiper
           swiperRef={swiperRef}
           query={query}

--- a/components/form-fields/ComboBoxField.tsx
+++ b/components/form-fields/ComboBoxField.tsx
@@ -37,10 +37,6 @@ interface ComboBoxFieldProps<Clearable extends boolean | undefined>
    */
   changeBehavior?: 'append' | 'filter'
   textFieldProps?: Partial<TextFieldProps>
-  /** Helper text defaults to a single whitespace to provide padding.
-   *  To disable, set to an empty string.
-   */
-  helperText?: string
 }
 /** This component is setup for memoization. For memoization to work any functions passed in
  *  must be wrapped in useCallback(). Eg, handleSubmit().
@@ -55,7 +51,6 @@ export default memo(function ComboBoxField<
   handleChange = doNothing,
   changeBehavior = 'append',
   textFieldProps,
-  helperText = ' ',
   ...asyncAutocompleteProps
 }: ComboBoxFieldProps<Clearable>) {
   const { control, value, setValue } = useField<string[]>({
@@ -112,10 +107,7 @@ export default memo(function ComboBoxField<
           </li>
         )
       }}
-      textFieldProps={{
-        helperText,
-        ...textFieldProps,
-      }}
+      textFieldProps={textFieldProps}
       {...asyncAutocompleteProps}
     />
   )

--- a/components/form-fields/EquipmentWeightField.tsx
+++ b/components/form-fields/EquipmentWeightField.tsx
@@ -36,7 +36,6 @@ export default function EquipmentWeightField({ weight, handleUpdate }: Props) {
       )}
       fullWidth
       variant="outlined"
-      defaultHelperText=" "
       slotProps={{
         input: {
           endAdornment: (

--- a/components/form-fields/InputField.tsx
+++ b/components/form-fields/InputField.tsx
@@ -1,5 +1,6 @@
 import CheckIcon from '@mui/icons-material/Check'
 import ReplayIcon from '@mui/icons-material/Replay'
+import Collapse from '@mui/material/Collapse'
 import type { InputProps } from '@mui/material/Input'
 import TextField, { type TextFieldProps } from '@mui/material/TextField'
 import { useRef } from 'react'
@@ -10,21 +11,21 @@ interface Props
   extends Pick<UseFieldProps, 'required' | 'handleSubmit' | 'handleValidate'> {
   label: string
   initialValue?: string
-  defaultHelperText?: string
   /** Overrides internal behavior of when to show submit button.
    *  Has no effect if undefined.
    */
   showSubmit?: boolean
+  useErrorTransition?: boolean
 }
 export default function InputField(props: Props & TextFieldProps) {
   const {
     label,
     initialValue = '',
-    defaultHelperText = ' ',
     handleSubmit,
     required,
     handleValidate,
     showSubmit,
+    useErrorTransition,
     ...textFieldProps
   } = props
 
@@ -42,13 +43,21 @@ export default function InputField(props: Props & TextFieldProps) {
     inputRef.current?.focus()
   }
 
+  const displayedError = useErrorTransition ? (
+    <Collapse in={!!error}>
+      <span>{error}</span>
+    </Collapse>
+  ) : (
+    error
+  )
+
   return (
     <TextField
       {...textFieldProps}
       {...control(label)}
-      error={!!error}
       autoComplete="off"
-      helperText={error || defaultHelperText}
+      error={!!error}
+      helperText={displayedError || textFieldProps.helperText}
       onKeyDown={(e) => {
         if (e.code === 'Enter') {
           submit()
@@ -58,6 +67,10 @@ export default function InputField(props: Props & TextFieldProps) {
       inputRef={inputRef}
       slotProps={{
         ...textFieldProps.slotProps,
+        formHelperText: {
+          // default <p> cannot contain any children
+          component: 'div',
+        },
         input: {
           ...textFieldProps.slotProps?.input,
           endAdornment: (

--- a/components/form-fields/InputFieldAutosave.tsx
+++ b/components/form-fields/InputFieldAutosave.tsx
@@ -14,7 +14,6 @@ const numericInput: InputHTMLAttributes<HTMLInputElement> = {
 export type InputFieldAutosaveProps = {
   label?: string
   initialValue?: string
-  defaultHelperText?: string
   handleSubmit: (value: string) => void
   readOnly?: boolean
   /** Render an Input instead of a TextField. This will allow label / helper text to
@@ -43,7 +42,6 @@ export type InputFieldAutosaveProps = {
 export default function InputFieldAutosave(props: InputFieldAutosaveProps) {
   const {
     label,
-    defaultHelperText = ' ',
     initialValue = '',
     handleSubmit,
     readOnly,
@@ -113,7 +111,7 @@ export default function InputFieldAutosave(props: InputFieldAutosaveProps) {
       onChange={handleChange}
       // autoselect on focus highlights input for easy overwriting
       onFocus={handleFocus}
-      helperText={error || defaultHelperText}
+      helperText={error}
       {...textFieldProps}
       slotProps={{
         ...textFieldProps.slotProps,

--- a/components/form-fields/NameField.tsx
+++ b/components/form-fields/NameField.tsx
@@ -22,6 +22,7 @@ export default memo(function NameField({
         (name: string) => handleUpdate({ name }),
         [handleUpdate]
       )}
+      useErrorTransition
       handleValidate={(newName) =>
         newName !== name && existingNames.find((n) => n === newName)
           ? 'Already exists!'

--- a/components/form-fields/NumericFieldAutosave.tsx
+++ b/components/form-fields/NumericFieldAutosave.tsx
@@ -22,7 +22,6 @@ export default function NumericFieldAutosave({
       initialValue={String(initialValue ?? '')}
       handleSubmit={(str) => handleNumberSubmit(convertValueToNumber(str))}
       variant="standard"
-      defaultHelperText=""
       isNumeric
       {...inputFieldAutosaveProps}
     />

--- a/components/form-fields/SelectFieldAutosave.tsx
+++ b/components/form-fields/SelectFieldAutosave.tsx
@@ -7,7 +7,6 @@ interface Props<V extends string | undefined | null, O>
   extends Omit<UseFieldProps<V>, 'debounceMilliseconds' | 'autoSubmit'> {
   label: string
   options: O[]
-  defaultHelperText?: string
   children?: ReactNode
   readOnly?: boolean
   /** label for empty option  */
@@ -22,7 +21,6 @@ export default function SelectFieldAutosave<
 >(props: Props<V, O> & Omit<TextFieldProps, 'SelectProps'>) {
   const {
     label,
-    defaultHelperText = ' ',
     options,
     initialValue,
     handleSubmit,
@@ -45,7 +43,6 @@ export default function SelectFieldAutosave<
     <TextField
       {...control(label)}
       select
-      helperText={defaultHelperText}
       {...textFieldProps}
       slotProps={{
         ...textFieldProps.slotProps,

--- a/components/form-fields/actions/ActionItems.tsx
+++ b/components/form-fields/actions/ActionItems.tsx
@@ -43,7 +43,7 @@ export default function ActionItems({
       {type === 'exercise' && (
         <ActionItem
           description="View the most recent dates when this exercise has been used."
-          button={<UsageButton exercise={name} type="text" />}
+          button={<UsageButton exerciseId={id} type="text" />}
         />
       )}
       {handleDelete && (

--- a/components/form-fields/actions/UsageButton.test.tsx
+++ b/components/form-fields/actions/UsageButton.test.tsx
@@ -1,23 +1,30 @@
 import { expect, it, vi } from 'vitest'
-import { fetchRecords } from '../../../lib/backend/mongoService'
+import { fetchExercises, fetchRecords } from '../../../lib/backend/mongoService'
 import { render, screen, waitFor } from '../../../lib/test/rtl'
 import { createExercise } from '../../../models/AsyncSelectorOption/Exercise'
 import { createRecord } from '../../../models/Record'
 import { DB_UNITS } from '../../../models/Units'
 import UsageButton from './UsageButton'
 
+const squats = createExercise('squats', {
+  displayFields: {
+    visibleFields: [],
+    units: { ...DB_UNITS, weight: 'lbs' },
+  },
+})
+
 it('displays usage when clicked', async () => {
   const date = '2020-02-02'
-  const record = createRecord(date, {
+  const record = createRecord(date, 'ex1', {
     sets: [{ reps: 6 }, { reps: 6 }],
     setType: { field: 'reps', operator: 'exactly', value: 6 },
   })
-  const singularRecord = createRecord('2000-02-02', {
+  const singularRecord = createRecord('2000-02-02', 'ex1', {
     sets: [{ reps: 6 }],
     setType: { field: 'reps', operator: 'exactly', value: 6 },
   })
   vi.mocked(fetchRecords).mockResolvedValue([record, singularRecord])
-  const { user } = render(<UsageButton exercise="name" type="text" />)
+  const { user } = render(<UsageButton exerciseId="ex1" type="text" />)
 
   // have to wait for server res
   await user.click(await screen.findByLabelText('used in 2 records'))
@@ -38,17 +45,12 @@ it('displays usage when clicked', async () => {
 
 it('shows singular label', async () => {
   const date = '2020-02-02'
-  const record = createRecord(date, {
+  const record = createRecord(date, squats._id, {
     setType: { operator: 'at least', value: 10, field: 'weight' },
-    exercise: createExercise('squats', {
-      displayFields: {
-        visibleFields: [],
-        units: { ...DB_UNITS, weight: 'lbs' },
-      },
-    }),
   })
   vi.mocked(fetchRecords).mockResolvedValue([record])
-  const { user } = render(<UsageButton exercise="name" type="text" />)
+  vi.mocked(fetchExercises).mockResolvedValue([squats])
+  const { user } = render(<UsageButton exerciseId={squats._id} type="text" />)
 
   await user.click(await screen.findByLabelText('used in 1 record'))
   expect(screen.getByText(/at least 10 lbs/)).toBeVisible()
@@ -56,17 +58,12 @@ it('shows singular label', async () => {
 
 it('displays as icon button', async () => {
   const date = '2020-02-02'
-  const record = createRecord(date, {
+  const record = createRecord(date, squats._id, {
     setType: { operator: 'at least', value: 10, field: 'weight' },
-    exercise: createExercise('squats', {
-      displayFields: {
-        visibleFields: [],
-        units: { ...DB_UNITS, weight: 'lbs' },
-      },
-    }),
   })
   vi.mocked(fetchRecords).mockResolvedValue([record])
-  const { user } = render(<UsageButton exercise="name" type="icon" />)
+  vi.mocked(fetchExercises).mockResolvedValue([squats])
+  const { user } = render(<UsageButton exerciseId={squats._id} type="icon" />)
 
   await user.click(await screen.findByLabelText('Recent usage'))
   expect(screen.getByText(/at least 10 lbs/)).toBeVisible()

--- a/components/form-fields/actions/UsageButton.tsx
+++ b/components/form-fields/actions/UsageButton.tsx
@@ -12,7 +12,7 @@ import ListItemButton from '@mui/material/ListItemButton'
 import ListItemText from '@mui/material/ListItemText'
 import Link from 'next/link'
 import { useState } from 'react'
-import { useRecords } from '../../../lib/frontend/data/useQuery'
+import { useExercise, useRecords } from '../../../lib/frontend/data/useQuery'
 import { stringifySetType } from '../../../models/Set'
 import LoadingSpinner from '../../loading/LoadingSpinner'
 import TooltipIconButton from '../../TooltipIconButton'
@@ -20,20 +20,21 @@ import TooltipIconButton from '../../TooltipIconButton'
 export const usageLimit = 11
 
 interface Props {
-  exercise?: string
+  exerciseId?: string
   buttonProps?: ButtonProps
   type: 'text' | 'icon'
 }
-export default function UsageButton({ exercise, type, buttonProps }: Props) {
+export default function UsageButton({ exerciseId, type, buttonProps }: Props) {
+  const exercise = useExercise(exerciseId)
   const [open, setOpen] = useState(false)
   const handleOpen = () => setOpen(true)
   const handleClose = () => setOpen(false)
   const { data: records, isLoading } = useRecords(
     {
-      exercise,
+      exerciseId,
       limit: usageLimit,
     },
-    !!exercise && (open || type === 'text')
+    !!exerciseId && (open || type === 'text')
   )
 
   return (
@@ -62,13 +63,13 @@ export default function UsageButton({ exercise, type, buttonProps }: Props) {
         <TooltipIconButton
           title="Recent usage"
           onClick={handleOpen}
-          disabled={!exercise}
+          disabled={!exerciseId}
         >
           <ListIcon />
         </TooltipIconButton>
       )}
       <Dialog open={open} onClose={handleClose}>
-        <DialogTitle>Usage for {exercise}</DialogTitle>
+        <DialogTitle>Usage for {exercise?.name}</DialogTitle>
         <DialogContent sx={{ py: 0 }}>
           {!records ? (
             <LoadingSpinner />
@@ -76,7 +77,7 @@ export default function UsageButton({ exercise, type, buttonProps }: Props) {
             <List disablePadding>
               {records
                 .slice(0, usageLimit)
-                .map(({ date, setType, sets, exercise, _id }) => (
+                .map(({ date, setType, sets, _id }) => (
                   // Note: this is Nextjs Link, not mui
                   <Link key={_id} href={`/sessions/${date}?record=${_id}`}>
                     <ListItem disablePadding>

--- a/components/forms/CategoryForm.tsx
+++ b/components/forms/CategoryForm.tsx
@@ -54,7 +54,7 @@ export default function CategoryForm({ category: { name, _id } }: Props) {
   )
 
   return (
-    <Grid container spacing={1} size={12}>
+    <Grid container spacing={2} size={12}>
       <Grid size={12}>
         <NameField
           name={name}

--- a/components/forms/ExerciseForm.tsx
+++ b/components/forms/ExerciseForm.tsx
@@ -43,7 +43,7 @@ export default function ExerciseForm({ exercise }: Props) {
   const exerciseNames = useExerciseNames()
   // Match the query from UsageButton to reuse the same key.
   // This is only used in this component to determine if "delete" is disabled.
-  const { data: records } = useRecords({ exercise: name, limit: usageLimit })
+  const { data: records } = useRecords({ exerciseId: _id, limit: usageLimit })
   const [_, setUrlExercise] = useQueryState('exercise')
   const addExerciseMutate = useAddMutation({
     queryKey: [QUERY_KEYS.exercises],

--- a/components/forms/ExerciseForm.tsx
+++ b/components/forms/ExerciseForm.tsx
@@ -88,7 +88,7 @@ export default function ExerciseForm({ exercise }: Props) {
   }, [addExerciseMutate, exercise, setUrlExercise])
 
   return (
-    <Grid container spacing={1} size={12}>
+    <Grid container spacing={2} size={12}>
       <Grid size={12}>
         <NameField
           name={name}

--- a/components/forms/ModifierForm.tsx
+++ b/components/forms/ModifierForm.tsx
@@ -57,7 +57,7 @@ export default function ModifierForm({
   )
 
   return (
-    <Grid container spacing={1} size={12}>
+    <Grid container spacing={2} size={12}>
       <Grid
         size={{
           xs: 12,

--- a/components/history/HistoryGraph.tsx
+++ b/components/history/HistoryGraph.tsx
@@ -28,7 +28,11 @@ import {
   DATE_FORMAT,
   DEFAULT_CLOTHING_OFFSET,
 } from '../../lib/frontend/constants'
-import { useBodyweights, useRecords } from '../../lib/frontend/data/useQuery'
+import {
+  useBodyweights,
+  useExercise,
+  useRecords,
+} from '../../lib/frontend/data/useQuery'
 import useDesktopCheck from '../../lib/frontend/useDesktopCheck'
 import type { PartialUpdate } from '../../lib/types'
 import type { Bodyweight } from '../../models/Bodyweight'
@@ -104,6 +108,7 @@ export default function HistoryGraph({ query, swipeToRecord }: Props) {
   const isDark = useDarkMode()
   const bodyweightColor = isDark ? green[500] : green[800]
   const exerciseColor = palette.primary[isDark ? 'light' : 'dark']
+  const exercise = useExercise(query.exerciseId)
 
   // BWs and records are sorted newest first. It looks more natural in the
   // swiper to start on the right and move left vs oldest first.
@@ -134,7 +139,7 @@ export default function HistoryGraph({ query, swipeToRecord }: Props) {
     graphOptions
   const lineType = smoothLine ? 'basis' : 'monotone'
   // only fetch if there is an exercise selected
-  const { data: records } = useRecords(query, !!query.exercise)
+  const { data: records } = useRecords(query, !!query.exerciseId)
 
   const updateRecordDisplay: PartialUpdate<RecordDisplay> = (changes) =>
     setRecordDisplay((prev) => ({ ...prev, ...changes }))
@@ -160,7 +165,7 @@ export default function HistoryGraph({ query, swipeToRecord }: Props) {
     // When querying records with a set start date, there needs to be one extra bw
     // record from before the start date to associate with the first record.
     // Note: BWs are sorted newest to oldest, so it goes at the end.
-    return query.exercise && query.start
+    return query.exerciseId && query.start
       ? [...baseData, ...earliestRecordBw]
       : baseData
   }, [
@@ -169,7 +174,7 @@ export default function HistoryGraph({ query, swipeToRecord }: Props) {
     earliestRecordOfficialBw,
     includeUnofficial,
     officialBWs,
-    query.exercise,
+    query.exerciseId,
     query.start,
   ])
 
@@ -223,7 +228,7 @@ export default function HistoryGraph({ query, swipeToRecord }: Props) {
 
   const graphData = useMemo((): GraphData[] => {
     // when there's no exercise, just show BW data
-    if (!query.exercise || !records) {
+    if (!query.exerciseId || !records) {
       return bodyweightGraphData.map((bw) => ({
         unixDate: dayjs(bw.date).unix(),
         bodyweight: bw.value,
@@ -307,11 +312,11 @@ export default function HistoryGraph({ query, swipeToRecord }: Props) {
     bodyweightGraphData,
     clothingOffset,
     includeUnofficial,
-    query.exercise,
     recordDisplay.operator,
     records,
     setReducer,
     recordDisplay.grouping,
+    query.exerciseId,
   ])
 
   return (
@@ -363,7 +368,7 @@ export default function HistoryGraph({ query, swipeToRecord }: Props) {
                 dataKey="bodyweight"
                 type="number"
                 unit=" kg"
-                orientation={query.exercise ? 'right' : 'left'}
+                orientation={query.exerciseId ? 'right' : 'left'}
                 stroke={bodyweightColor}
                 domain={['auto', 'auto']}
               />
@@ -377,7 +382,7 @@ export default function HistoryGraph({ query, swipeToRecord }: Props) {
               />
             </>
           )}
-          {query.exercise && (
+          {query.exerciseId && (
             <>
               <YAxis
                 yAxisId="exercise"
@@ -394,7 +399,7 @@ export default function HistoryGraph({ query, swipeToRecord }: Props) {
 
               <Line
                 yAxisId="exercise"
-                name={query.exercise}
+                name={exercise?.name}
                 dataKey="value"
                 stroke={exerciseColor}
                 type={lineType}

--- a/components/history/ModifierQueryField.tsx
+++ b/components/history/ModifierQueryField.tsx
@@ -25,7 +25,6 @@ export default function ModifierQueryField({
       options={options || []}
       initialValue={initialValue || []}
       handleSubmit={(modifiers) => updateQuery({ modifiers })}
-      helperText=""
       startAdornment={
         <MatchTypeSelector
           matchType={matchType}

--- a/components/history/QueryForm.test.tsx
+++ b/components/history/QueryForm.test.tsx
@@ -76,12 +76,15 @@ it('clears exercise', async () => {
 })
 
 it('keeps possible modifiers after swapping exercise', async () => {
+  const squats = createExercise('squats', { modifiers: ['belt', 'band'] })
   vi.mocked(fetchExercises).mockResolvedValue([
-    createExercise('squats', { modifiers: ['belt', 'band'] }),
+    squats,
     createExercise('bench', { modifiers: ['belt', 'slow'] }),
   ])
   const { user } = render(
-    <TestWrapper query={{ exercise: 'squats', modifiers: ['belt', 'band'] }} />
+    <TestWrapper
+      query={{ exerciseId: squats._id, modifiers: ['belt', 'band'] }}
+    />
   )
 
   await user.click(screen.getByLabelText('Exercise'))

--- a/components/history/QueryForm.tsx
+++ b/components/history/QueryForm.tsx
@@ -37,7 +37,7 @@ export default function QueryForm({ query, updateQuery }: Props) {
             (modifier) => exercise?.modifiers.some((ex) => ex === modifier)
           )
           updateUnsavedQuery({
-            exercise: exercise?.name ?? '',
+            exerciseId: exercise?._id,
             modifiers: remainingModifiers,
           })
         }}

--- a/components/session/AddRecordCard.tsx
+++ b/components/session/AddRecordCard.tsx
@@ -20,6 +20,7 @@ export default function AddRecordCard() {
     addFn: addRecord,
   })
   const handleAdd = async () => {
+    /* v8 ignore next */
     if (!exercise) return
 
     addRecordMutate(createRecord(date, exercise._id))

--- a/components/session/AddRecordCard.tsx
+++ b/components/session/AddRecordCard.tsx
@@ -20,7 +20,9 @@ export default function AddRecordCard() {
     addFn: addRecord,
   })
   const handleAdd = async () => {
-    addRecordMutate(createRecord(date, { exercise }))
+    if (!exercise) return
+
+    addRecordMutate(createRecord(date, exercise._id))
 
     swiper.update()
     setExercise(null)

--- a/components/session/CopySessionCard.test.tsx
+++ b/components/session/CopySessionCard.test.tsx
@@ -10,7 +10,7 @@ import { createSessionLog } from '../../models/SessionLog'
 import CopySessionCard from './CopySessionCard'
 
 it('copies session', async () => {
-  const prevRecord = createRecord('2000-01-01')
+  const prevRecord = createRecord('2000-01-01', '1')
   vi.mocked(fetchSessionLog).mockResolvedValue(
     createSessionLog('2000-01-01', [prevRecord._id])
   )

--- a/components/session/CopySessionCard.tsx
+++ b/components/session/CopySessionCard.tsx
@@ -52,7 +52,9 @@ export default function CopySessionCard() {
     // See: https://stackoverflow.com/questions/37576685/using-async-await-with-a-foreach-loop
     for (const id of prevSessionLog.data.records) {
       const prevRecord = prevRecords.index[id]
-      const newRecord = createRecord(date, {
+      if (!prevRecord) continue
+
+      const newRecord = createRecord(date, prevRecord.exerciseId, {
         ...prevRecord,
         notes: [],
       })

--- a/components/session/CopySessionCard.tsx
+++ b/components/session/CopySessionCard.tsx
@@ -52,6 +52,7 @@ export default function CopySessionCard() {
     // See: https://stackoverflow.com/questions/37576685/using-async-await-with-a-foreach-loop
     for (const id of prevSessionLog.data.records) {
       const prevRecord = prevRecords.index[id]
+      /* v8 ignore next */
       if (!prevRecord) continue
 
       const newRecord = createRecord(date, prevRecord.exerciseId, {

--- a/components/session/history/HistoryCard.test.tsx
+++ b/components/session/history/HistoryCard.test.tsx
@@ -1,9 +1,16 @@
-import { expect, it } from 'vitest'
+import { beforeEach, expect, it, vi } from 'vitest'
+import { fetchExercises } from '../../../lib/backend/mongoService'
 import { render, screen } from '../../../lib/test/rtl'
 import { createExercise } from '../../../models/AsyncSelectorOption/Exercise'
 import { DEFAULT_DISPLAY_FIELDS } from '../../../models/DisplayFields'
 import { createRecord } from '../../../models/Record'
 import HistoryCard from './HistoryCard'
+
+const squats = createExercise('squats')
+
+beforeEach(() => {
+  vi.mocked(fetchExercises).mockResolvedValue([squats])
+})
 
 it('shows custom display fields', async () => {
   render(
@@ -12,8 +19,7 @@ it('shows custom display fields', async () => {
         ...DEFAULT_DISPLAY_FIELDS,
         visibleFields: [{ name: 'plateWeight', source: 'weight' }],
       }}
-      record={createRecord('2000-01-01', {
-        exercise: createExercise('squats'),
+      record={createRecord('2000-01-01', squats._id, {
         sets: [{ weight: 5, reps: 5 }],
       })}
       content={['sets']}
@@ -26,8 +32,7 @@ it('shows custom display fields', async () => {
 it('shows provided content and actions', async () => {
   render(
     <HistoryCard
-      record={createRecord('2000-01-01', {
-        exercise: createExercise('squats'),
+      record={createRecord('2000-01-01', squats._id, {
         sets: [{ weight: 5, reps: 5 }],
       })}
       actions={['recordNotes']}
@@ -36,7 +41,7 @@ it('shows provided content and actions', async () => {
     />
   )
 
-  expect(screen.getByDisplayValue('squats')).toBeVisible()
+  expect(await screen.findByDisplayValue('squats')).toBeVisible()
   expect(screen.getByLabelText('Record notes')).toBeVisible()
 
   expect(screen.queryByDisplayValue('5')).not.toBeInTheDocument()

--- a/components/session/history/HistoryCard.tsx
+++ b/components/session/history/HistoryCard.tsx
@@ -7,6 +7,7 @@ import Link from 'next/link'
 import type { JSX } from 'react'
 import ComboBoxField from '../../../components/form-fields/ComboBoxField'
 import StyledDivider from '../../../components/StyledDivider'
+import { useExercise } from '../../../lib/frontend/data/useQuery'
 import useDisplayFields from '../../../lib/frontend/useDisplayFields'
 import useExtraWeight from '../../../lib/frontend/useExtraWeight'
 import type { DisplayFields } from '../../../models/DisplayFields'
@@ -38,7 +39,9 @@ export default function HistoryCard({
   cardProps,
   ...props
 }: Props) {
-  const { sets, _id, notes, date, exercise, activeModifiers, setType } = record
+  const { sets, _id, notes, date, exerciseId, activeModifiers, setType } =
+    record
+  const exercise = useExercise(exerciseId)
   const recordDisplayFields = useDisplayFields(exercise)
   const { extraWeight, exerciseWeight } = useExtraWeight(record)
 
@@ -57,7 +60,7 @@ export default function HistoryCard({
     exerciseNotes: (
       <ExerciseNotesButton key="exercise notes" notes={exercise?.notes} />
     ),
-    manage: <ManageExerciseButton key="manage" _id={exercise?._id} />,
+    manage: <ManageExerciseButton key="manage" _id={exerciseId} />,
   }
 
   const contentComponents: { [key in HistoryContent]: JSX.Element } = {
@@ -66,7 +69,7 @@ export default function HistoryCard({
         key="exercise"
         label="Exercise"
         variant="standard"
-        value={exercise?.name}
+        value={exercise?.name ?? ''}
         slotProps={{
           input: { readOnly: true },
         }}

--- a/components/session/history/HistoryCard.tsx
+++ b/components/session/history/HistoryCard.tsx
@@ -82,7 +82,6 @@ export default function HistoryCard({
         options={activeModifiers}
         initialValue={activeModifiers}
         variant="standard"
-        helperText=""
         readOnly
       />
     ),

--- a/components/session/records/RecordCard.test.tsx
+++ b/components/session/records/RecordCard.test.tsx
@@ -6,22 +6,18 @@ import {
   updateExerciseFields,
   updateRecordFields,
 } from '../../../lib/backend/mongoService'
+import { createTestRecord, testExercise } from '../../../lib/test/data'
 import { render, screen } from '../../../lib/test/rtl'
 import { ignoreConsoleErrorOnce } from '../../../lib/util/test/console'
 import { createExercise } from '../../../models/AsyncSelectorOption/Exercise'
-import { createRecord } from '../../../models/Record'
 import RecordCard from './RecordCard'
-
-const exercise = createExercise('finger curls')
 
 it('mutates', async () => {
   localStorage.setItem('cardHeaderActions', '10') // avoid needing to click "More..."
-  const record = createRecord('2000-01-01', {
-    exercise,
-  })
+  const record = createTestRecord()
   vi.mocked(fetchRecords).mockResolvedValue([record])
   vi.mocked(fetchExercises).mockResolvedValue([
-    exercise,
+    testExercise,
     createExercise('other'),
   ])
   const { user } = render(
@@ -42,12 +38,9 @@ it('mutates', async () => {
 })
 
 it('displays error when update fails', async () => {
-  const squats = createExercise('squats')
-  const record = createRecord('2000-01-01', {
-    exercise: squats,
-  })
+  const record = createTestRecord()
   vi.mocked(fetchRecords).mockResolvedValue([record])
-  vi.mocked(fetchExercises).mockResolvedValue([squats])
+  vi.mocked(fetchExercises).mockResolvedValue([testExercise])
   const { user } = render(
     <RecordCard id={record._id} date={record.date} swiperIndex={0} />
   )

--- a/components/session/records/RecordCard.tsx
+++ b/components/session/records/RecordCard.tsx
@@ -52,8 +52,8 @@ export default function RecordCard({ swiperIndex, id, date }: Props) {
   // same exercise. record.exercise is only updated upon fetching the record,
   // so if one record updated an exercise any other records would still be using the outdated exercise.
   const record = useRecord(id, date)
-  const exercise = useExercise(record.exercise?._id)
-  const { activeModifiers, _id, sets, notes, setType } = record
+  const { activeModifiers, _id, sets, notes, setType, exerciseId } = record
+  const exercise = useExercise(exerciseId)
   const displayFields = useDisplayFields(exercise)
   const { extraWeight, exerciseWeight } = useExtraWeight(record)
   const noSwipingDesktop = useNoSwipingDesktop()
@@ -65,20 +65,19 @@ export default function RecordCard({ swiperIndex, id, date }: Props) {
       modifiers: activeModifiers,
       // don't want to include the current record in its own history
       end: dayjs(date).add(-1, 'day').format(DATE_FORMAT),
-      exercise: exercise?.name,
+      exerciseId: exerciseId,
       limit: 5,
       modifierMatchType: ArrayMatchType.Exact,
       setTypeMatchType: ArrayMatchType.Exact,
       setType,
     }),
-    [activeModifiers, date, exercise?.name, setType]
+    [activeModifiers, date, exerciseId, setType]
   )
 
   return (
     <Card elevation={3} sx={{ px: 1, m: 0.5 }}>
       <RecordCardHeader
         exerciseId={exercise?._id}
-        exerciseName={exercise?.name}
         exerciseNotes={exercise?.notes}
         {...{
           swiperIndex,
@@ -106,7 +105,7 @@ export default function RecordCard({ swiperIndex, id, date }: Props) {
             availableModifiers={exercise?.modifiers}
             {...{ _id, activeModifiers }}
           />
-          <RecordSetTypeSelect {...{ _id, date }} />
+          <RecordSetTypeSelect {...{ _id, date, units: displayFields.units }} />
           <RenderSets
             exerciseId={exercise?._id}
             {...{

--- a/components/session/records/RecordExerciseSelector.test.tsx
+++ b/components/session/records/RecordExerciseSelector.test.tsx
@@ -30,7 +30,7 @@ it('filters modifiers to match the new exercise on switch', async () => {
   await user.click(screen.getByText(some.name))
 
   expect(updateRecordFields).toHaveBeenCalledWith('1', {
-    exercise: some,
+    exerciseId: some._id,
     activeModifiers: some.modifiers,
   })
 })

--- a/components/session/records/RecordExerciseSelector.tsx
+++ b/components/session/records/RecordExerciseSelector.tsx
@@ -28,6 +28,7 @@ export default memo(function RecordExerciseSelector<
 }: Props<DisableClearable>) {
   const updateRecord = useRecordUpdate(_id)
   const handleChange = async (newExercise: Exercise | null) => {
+    /* v8 ignore next */
     if (!newExercise) return
 
     // if an exercise changes, discard any modifiers that are not valid for the new exercise

--- a/components/session/records/RecordExerciseSelector.tsx
+++ b/components/session/records/RecordExerciseSelector.tsx
@@ -28,13 +28,15 @@ export default memo(function RecordExerciseSelector<
 }: Props<DisableClearable>) {
   const updateRecord = useRecordUpdate(_id)
   const handleChange = async (newExercise: Exercise | null) => {
+    if (!newExercise) return
+
     // if an exercise changes, discard any modifiers that are not valid for the new exercise
     const remainingModifiers = activeModifiers.filter((modifier) =>
       newExercise?.modifiers.some((exercise) => exercise === modifier)
     )
 
     updateRecord({
-      exercise: newExercise,
+      exerciseId: newExercise?._id,
       activeModifiers: remainingModifiers,
     })
   }

--- a/components/session/records/RecordModifierComboBox.tsx
+++ b/components/session/records/RecordModifierComboBox.tsx
@@ -21,7 +21,6 @@ export default function RecordModifierComboBox({
       options={availableModifiers?.sort()}
       initialValue={activeModifiers}
       variant="standard"
-      helperText=""
       handleSubmit={(value: string[]) =>
         updateRecord({ activeModifiers: value })
       }

--- a/components/session/records/RecordSetTypeSelect.tsx
+++ b/components/session/records/RecordSetTypeSelect.tsx
@@ -1,22 +1,21 @@
-import { useExercise, useRecord } from '../../../lib/frontend/data/useQuery'
-import useDisplayFields from '../../../lib/frontend/useDisplayFields'
+import { useRecord } from '../../../lib/frontend/data/useQuery'
 import { calculateTotalValue } from '../../../models/Set'
+import type { Units } from '../../../models/Units'
 import SetTypeSelect from './SetTypeSelect'
 import { useRecordUpdate } from './useRecordUpdate'
 
 interface Props {
   _id: string
   date: string
+  units: Units
 }
-export default function RecordSetTypeSelect({ _id, date }: Props) {
+export default function RecordSetTypeSelect({ _id, date, units }: Props) {
   const updateRecord = useRecordUpdate(_id)
-  const { setType, sets, ...record } = useRecord(_id, date)
-  const exercise = useExercise(record.exercise?._id)
-  const displayFields = useDisplayFields(exercise)
+  const { setType, sets } = useRecord(_id, date)
 
   return (
     <SetTypeSelect
-      units={displayFields.units}
+      units={units}
       totalReps={calculateTotalValue(sets, setType)}
       showRemaining
       handleChange={updateRecord}

--- a/components/session/records/header/RecordCardHeader.test.tsx
+++ b/components/session/records/header/RecordCardHeader.test.tsx
@@ -19,7 +19,6 @@ const TestWrapper = (
       notes={[]}
       _id="1"
       exerciseId="ex1"
-      exerciseName="dips"
       exerciseNotes={[]}
       {...props}
     />

--- a/components/session/records/header/RecordCardHeader.tsx
+++ b/components/session/records/header/RecordCardHeader.tsx
@@ -69,7 +69,6 @@ interface Props {
   displayFields: DisplayFields
   date: string
   exerciseId?: string
-  exerciseName?: string
   exerciseNotes?: Note[]
 }
 export default function RecordCardHeader({
@@ -79,7 +78,6 @@ export default function RecordCardHeader({
   displayFields,
   date,
   exerciseId,
-  exerciseName,
   exerciseNotes,
 }: Props) {
   const actionButtons = [
@@ -90,7 +88,7 @@ export default function RecordCardHeader({
       notes={exerciseNotes}
       _id={exerciseId}
     />,
-    <UsageButton key="usage dialog" exercise={exerciseName} type="icon" />,
+    <UsageButton key="usage dialog" exerciseId={exerciseId} type="icon" />,
     <ManageExerciseButton key="manage" _id={exerciseId} />,
     <ChangeUnitsButton
       key="change units dialog"

--- a/components/session/records/header/RecordNotesButton.test.tsx
+++ b/components/session/records/header/RecordNotesButton.test.tsx
@@ -6,15 +6,15 @@ import {
   updateRecordFields,
   upsertSessionLog,
 } from '../../../../lib/backend/mongoService'
+import { createTestRecord } from '../../../../lib/test/data'
 import { render, screen, waitFor } from '../../../../lib/test/rtl'
 import { createNote } from '../../../../models/Note'
-import { createRecord } from '../../../../models/Record'
 import { createSessionLog } from '../../../../models/SessionLog'
 import ReccordNotesButton from './RecordNotesButton'
 
 const sessionLog = createSessionLog('2000-01-01')
 const note = createNote('note')
-const record = createRecord('2000-01-01')
+const record = createTestRecord()
 
 const TestWrapper = (
   props: Partial<ComponentProps<typeof ReccordNotesButton>>

--- a/components/session/records/sets/AddSetButton.test.tsx
+++ b/components/session/records/sets/AddSetButton.test.tsx
@@ -1,17 +1,16 @@
 import { expect, it, vi } from 'vitest'
 import { addSet, fetchRecords } from '../../../../lib/backend/mongoService'
 import { useRecords } from '../../../../lib/frontend/data/useQuery'
-import { testDate } from '../../../../lib/test/data'
+import { createTestRecord, testDate } from '../../../../lib/test/data'
 import { render, screen } from '../../../../lib/test/rtl'
-import { createRecord } from '../../../../models/Record'
 import type { Set } from '../../../../models/Set'
 import AddSetButton from './AddSetButton'
 
-const record = createRecord(testDate)
+const record = createTestRecord()
 const _id = record._id
 
 it('adds set to record', async () => {
-  const record2 = createRecord(testDate)
+  const record2 = createTestRecord()
   vi.mocked(fetchRecords).mockResolvedValue([record, record2])
   // this component has no way to visibly wait for the data, so need a wrapper
   const LoadedButton = () => {

--- a/components/session/records/sets/DeleteSetButton.test.tsx
+++ b/components/session/records/sets/DeleteSetButton.test.tsx
@@ -1,14 +1,13 @@
 import { expect, it, vi } from 'vitest'
 import { deleteSet, fetchRecords } from '../../../../lib/backend/mongoService'
 import { useRecords } from '../../../../lib/frontend/data/useQuery'
-import { testDate } from '../../../../lib/test/data'
+import { createTestRecord, testDate } from '../../../../lib/test/data'
 import { render, screen } from '../../../../lib/test/rtl'
-import { createRecord } from '../../../../models/Record'
 import DeleteSetButton from './DeleteSetButton'
 
 it('deletes', async () => {
-  const record = createRecord(testDate, { sets: [{}, {}] })
-  const record2 = createRecord(testDate)
+  const record = createTestRecord({ sets: [{}, {}] })
+  const record2 = createTestRecord()
   vi.mocked(fetchRecords).mockResolvedValue([record, record2])
   // this component has no way to visibly wait for the data, so need a wrapper
   const LoadedButton = () => {

--- a/components/session/records/sets/RenderSetRow.test.tsx
+++ b/components/session/records/sets/RenderSetRow.test.tsx
@@ -1,16 +1,19 @@
 import { expect, it, vi } from 'vitest'
 import { fetchRecords, updateSet } from '../../../../lib/backend/mongoService'
-import { testDate } from '../../../../lib/test/data'
+import { createTestRecord, testDate } from '../../../../lib/test/data'
 import { render, screen, waitFor } from '../../../../lib/test/rtl'
 import { DEFAULT_DISPLAY_FIELDS } from '../../../../models/DisplayFields'
 import { createRecord } from '../../../../models/Record'
 import RenderSetRow from './RenderSetRow'
 
 it('renders correct set', async () => {
-  const record = createRecord(testDate, {
+  const record = createTestRecord({
     sets: [{ reps: 1 }, { reps: 2 }],
   })
-  vi.mocked(fetchRecords).mockResolvedValue([createRecord(testDate), record])
+  vi.mocked(fetchRecords).mockResolvedValue([
+    createRecord(testDate, 'ex1'),
+    record,
+  ])
 
   const { user } = render(
     <RenderSetRow
@@ -34,7 +37,10 @@ it('renders correct set', async () => {
 })
 
 it('renders readonly set', async () => {
-  const record = createRecord('2000-01-01', { _id: '1', sets: [{ reps: 1 }] })
+  const record = createTestRecord({
+    _id: '1',
+    sets: [{ reps: 1 }],
+  })
   vi.mocked(fetchRecords).mockResolvedValue([record])
   render(
     <RenderSetRow

--- a/components/session/records/sets/SetFieldSide.tsx
+++ b/components/session/records/sets/SetFieldSide.tsx
@@ -24,7 +24,6 @@ export default function SetFieldSide({
       className={noSwipingClassName}
       variant="standard"
       label=""
-      helperText=""
       initialValue={value}
       options={['L', 'R']}
       emptyOption="Both"

--- a/components/session/records/sets/SetFieldTimeMask.tsx
+++ b/components/session/records/sets/SetFieldTimeMask.tsx
@@ -37,7 +37,6 @@ export default function SetFieldTimeMask({
       }}
       variant="standard"
       disableAutoSelect
-      defaultHelperText=""
       maskOptions={{ mask: '00:00:00', overwrite: true }}
       {...inputFieldProps}
     />

--- a/components/session/upper/BodyweightInput.tsx
+++ b/components/session/upper/BodyweightInput.tsx
@@ -89,7 +89,7 @@ export default function BodyweightInput({
           ),
         },
       }}
-      defaultHelperText={getHelperText()}
+      helperText={getHelperText()}
     />
   )
 }

--- a/lib/backend/mongoService.test.ts
+++ b/lib/backend/mongoService.test.ts
@@ -143,12 +143,6 @@ describe('Record', () => {
     // remove the modifier
     await updateExerciseFields(exercise._id, { modifiers: [] })
     expect(await fetchRecords({ activeModifiers: modifier.name })).toHaveLength(
-      0
-    )
-
-    // add it back -- record should still have the modifier
-    await updateExerciseFields(exercise._id, { modifiers: [modifier.name] })
-    expect(await fetchRecords({ activeModifiers: modifier.name })).toHaveLength(
       1
     )
   })

--- a/lib/backend/mongoService.test.ts
+++ b/lib/backend/mongoService.test.ts
@@ -5,8 +5,8 @@ import { createExercise } from '../../models/AsyncSelectorOption/Exercise'
 import { createModifier } from '../../models/AsyncSelectorOption/Modifier'
 import { createBodyweight } from '../../models/Bodyweight'
 import { createNote } from '../../models/Note'
-import { createRecord } from '../../models/Record'
 import { createSessionLog } from '../../models/SessionLog'
+import { createTestRecord, testDate, testExercise } from '../test/data'
 import { db } from './mongoConnect'
 import {
   addCategory,
@@ -49,7 +49,6 @@ vi.mock('./mongoConnect', async () => {
   return { client, db, clientPromise }
 })
 
-const testDate = '2000-01-01'
 const testDateNew = '2000-02-02'
 
 beforeEach(async () => {
@@ -58,7 +57,7 @@ beforeEach(async () => {
 
 describe('SessionLog', () => {
   it('fetches session logs for given user only', async () => {
-    await addRecord(createRecord(testDate))
+    await addRecord(createTestRecord())
     await upsertSessionLog(createSessionLog(testDateNew))
 
     vi.mocked(getUserId).mockResolvedValueOnce(new ObjectId())
@@ -70,7 +69,7 @@ describe('SessionLog', () => {
 
 describe('Record', () => {
   it('excludes userId', async () => {
-    const record = createRecord(testDate)
+    const record = createTestRecord()
     await addRecord(record)
 
     expect(await fetchRecord(record._id)).not.toMatchObject({
@@ -79,7 +78,7 @@ describe('Record', () => {
   })
 
   it('adds record and adds to session', async () => {
-    const record = createRecord(testDate)
+    const record = createTestRecord()
     await addRecord(record)
 
     // creates session
@@ -88,7 +87,7 @@ describe('Record', () => {
       records: [record._id],
     })
 
-    const record2 = createRecord(testDate)
+    const record2 = createTestRecord()
     await addRecord(record2)
 
     // updates existing session
@@ -98,9 +97,9 @@ describe('Record', () => {
   })
 
   it('deletes record and removes from session', async () => {
-    const record1 = await addRecord(createRecord(testDate))
-    const record2 = await addRecord(createRecord(testDate))
-    const record3 = await addRecord(createRecord(testDate))
+    const record1 = await addRecord(createTestRecord())
+    const record2 = await addRecord(createTestRecord())
+    const record3 = await addRecord(createTestRecord())
 
     await deleteRecord(record2._id)
 
@@ -115,14 +114,15 @@ describe('Record', () => {
       createExercise('squats', { modifiers: [modifier.name] })
     )
     await addRecord(
-      createRecord(testDate, { exercise, activeModifiers: [modifier.name] })
+      createTestRecord({
+        exerciseId: exercise._id,
+        activeModifiers: [modifier.name],
+      })
     )
-    await addRecord(createRecord(testDate, { exercise }))
-    await addRecord(createRecord(testDate))
+    await addRecord(createTestRecord({ exerciseId: exercise._id }))
+    await addRecord(createTestRecord())
 
-    expect(await fetchRecords({ 'exercise.name': exercise.name })).toHaveLength(
-      2
-    )
+    expect(await fetchRecords({ exerciseId: exercise._id })).toHaveLength(2)
     expect(await fetchRecords({ activeModifiers: modifier.name })).toHaveLength(
       1
     )
@@ -134,7 +134,10 @@ describe('Record', () => {
       createExercise('squats', { modifiers: [modifier.name] })
     )
     await addRecord(
-      createRecord(testDate, { exercise, activeModifiers: [modifier.name] })
+      createTestRecord({
+        exerciseId: exercise._id,
+        activeModifiers: [modifier.name],
+      })
     )
 
     // remove the modifier
@@ -151,7 +154,7 @@ describe('Record', () => {
   })
 
   it('overrides start/end with date', async () => {
-    await addRecord(createRecord(testDate))
+    await addRecord(createTestRecord())
 
     expect(
       await fetchRecords({ start: testDate, date: testDateNew })
@@ -168,7 +171,7 @@ describe('Record', () => {
   })
 
   it('returns updates record after modification', async () => {
-    const record = await addRecord(createRecord(testDate))
+    const record = await addRecord(createTestRecord())
 
     const updatedRecord = await updateRecordFields(record._id, {
       sets: [{ reps: 5 }],
@@ -178,7 +181,7 @@ describe('Record', () => {
 
   describe('Sets', () => {
     it('adds set', async () => {
-      const record = createRecord(testDate, { sets: [] })
+      const record = createTestRecord()
       await addRecord(record)
 
       expect(await addSet(record._id, { weight: 1 })).toMatchObject({
@@ -187,7 +190,7 @@ describe('Record', () => {
     })
 
     it('updates set', async () => {
-      const record = createRecord(testDate, {
+      const record = createTestRecord({
         sets: [{ distance: 1 }, { reps: 2 }, { weight: 3 }],
       })
       await addRecord(record)
@@ -198,7 +201,7 @@ describe('Record', () => {
     })
 
     it('deletes set', async () => {
-      const record = createRecord(testDate, {
+      const record = createTestRecord({
         sets: [{ distance: 1 }, { reps: 2 }, { weight: 3 }],
       })
       await addRecord(record)
@@ -227,8 +230,8 @@ describe('Exercise', () => {
   })
 
   it('prevents deleting exercise used in a record', async () => {
-    const exercise = await addExercise(createExercise('squats'))
-    await addRecord(createRecord(testDate, { exercise }))
+    const exercise = await addExercise(testExercise)
+    await addRecord(createTestRecord())
 
     await expect(deleteExercise(exercise._id)).rejects.toThrow()
   })
@@ -259,8 +262,8 @@ describe('Modifier', () => {
       })
     )
     const record = await addRecord(
-      createRecord(testDate, {
-        exercise,
+      createTestRecord({
+        exerciseId: exercise._id,
         activeModifiers: [modifier.name],
       })
     )

--- a/lib/backend/mongoService.ts
+++ b/lib/backend/mongoService.ts
@@ -1,5 +1,5 @@
 'use server'
-import type { Document, Filter } from 'mongodb'
+import type { Filter } from 'mongodb'
 import type { Category } from '../../models/AsyncSelectorOption/Category'
 import type { Exercise } from '../../models/AsyncSelectorOption/Exercise'
 import type { Modifier } from '../../models/AsyncSelectorOption/Modifier'
@@ -76,54 +76,6 @@ export async function upsertSessionLog(
 // RECORD
 //--------
 
-interface RecordPipeline {
-  // Unwind returns a record for every item in the array (we only have one or zero items).
-  /** $lookup the exercise based on the exercise _id to ensure we have the current data.
-   * This returns an array so we need to unwind it. */
-  lookupExercise: Document
-  /** $unwind the exercise array returned by $lookup. This produces a new document for every
-   *  element in the array. Eeach record can only have zero or one exercise.
-   *  We must enable preserveNullAndEmptyArrays or records without an exercise would just
-   *  be returned as "null".
-   */
-  unwindExercise: Document
-  /** $set activeModifiers to only contain elements that exist in exercise.modifiers.
-   *  This addresses if the user removes a modifier from an exercise --
-   *  the modifier should no longer appear in records. We maintain the data though,
-   *  in case the user re-adds the modifier in the future. This stage should be invoked
-   *  after $unwinding the exercise.
-   */
-  setActiveModifiers: Document
-  /** $project to exclude userId in the record and exercise */
-  excludeUserIds: Document
-}
-/** Shared aggregation stages for record fetches. */
-const recordPipeline: RecordPipeline = {
-  lookupExercise: {
-    $lookup: {
-      from: 'exercises',
-      localField: 'exercise._id',
-      foreignField: '_id',
-      as: 'exercise',
-    },
-  },
-  unwindExercise: {
-    $unwind: { path: '$exercise', preserveNullAndEmptyArrays: true },
-  },
-  setActiveModifiers: {
-    $set: {
-      activeModifiers: {
-        $filter: {
-          input: '$activeModifiers',
-          as: 'modifiers',
-          cond: { $in: ['$$modifiers', '$exercise.modifiers'] },
-        },
-      },
-    },
-  },
-  excludeUserIds: { $project: { userId: 0, 'exercise.userId': 0 } },
-}
-
 export async function addRecord(record: Record): Promise<Record> {
   const userId = await getUserId()
   await records.insertOne({ ...record, userId })
@@ -150,35 +102,17 @@ export async function fetchRecords({
   sort = 'newestFirst',
   ...filter
 }: Filter<Record> & FetchOptions = {}): Promise<Record[]> {
-  // Records do not store up-to-date exercise data; they pull in updated data on fetch.
-  // So for this query anything within the "exercise" object must be
-  // matched AFTER the exercises $lookup.
-  // For better efficiency we can split the filter into pre and post $lookup matches.
-  // We put as much as possible in pre-lookup to reduce the amount of exercise lookup
-  // (instead of looking up the exercise for every record first before starting to filter),
-  // and only put the filters that depend on current exercise data into post-lookup.
-  const { 'exercise.name': name, activeModifiers, ...otherFilters } = filter
   const userId = await getUserId()
 
   return await records
-    .aggregate<Record>([
+    .find<Record>(
       {
-        $match: {
-          date: { $gte: start, $lte: end },
-          ...otherFilters,
-          userId,
-        },
+        date: { $gte: start, $lte: end },
+        ...filter,
+        userId,
       },
-      recordPipeline.lookupExercise,
-      {
-        $match: name ? { 'exercise.name': name } : {},
-      },
-      recordPipeline.unwindExercise,
-      recordPipeline.setActiveModifiers,
-      // have to match modifiers after we set the corrected activeModifiers
-      { $match: activeModifiers ? { activeModifiers } : {} },
-      recordPipeline.excludeUserIds,
-    ])
+      { projection: { userId: 0 } }
+    )
     .sort({ date: convertSort(sort) })
     // Mongo docs say passing limit of 0 is equivalent to no limit,
     // but that actually results in an error saying limit must be a positive 64 bit int.
@@ -190,16 +124,7 @@ export async function fetchRecords({
 export async function fetchRecord(_id: string): Promise<Record | null> {
   const userId = await getUserId()
   const record = await records
-    .aggregate<Record>([
-      { $match: { userId, _id } },
-
-      recordPipeline.lookupExercise,
-
-      recordPipeline.unwindExercise,
-
-      recordPipeline.setActiveModifiers,
-      recordPipeline.excludeUserIds,
-    ])
+    .find<Record>({ userId, _id }, { projection: { userId: 0 } })
     // return just the first (there's only the one)
     .next()
 
@@ -317,7 +242,7 @@ export async function updateExerciseFields(
 
 export async function deleteExercise(_id: string) {
   const userId = await getUserId()
-  const used = await records.findOne({ userId, 'exercise._id': _id })
+  const used = await records.findOne({ userId, exerciseId: _id })
 
   if (used) {
     throw new Error(

--- a/lib/frontend/useExtraWeight.test.ts
+++ b/lib/frontend/useExtraWeight.test.ts
@@ -1,21 +1,21 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { createExercise } from '../../models/AsyncSelectorOption/Exercise'
+import {
+  createExercise,
+  type Exercise,
+} from '../../models/AsyncSelectorOption/Exercise'
 import { type Bodyweight, createBodyweight } from '../../models/Bodyweight'
-import { createRecord } from '../../models/Record'
+import { createTestRecord } from '../test/data'
 import { renderHook } from '../test/rtl'
 import useExtraWeight from './useExtraWeight'
 
 const exercise = createExercise('test exercise', {
   modifiers: ['light', 'heavy'],
 })
-const record = createRecord('2000-01-01', { exercise })
-const bwRecord = {
-  ...record,
-  exercise: {
-    ...exercise,
-    attributes: { bodyweight: true },
-  },
+const bwExercise = {
+  ...exercise,
+  attributes: { bodyweight: true },
 }
+const record = createTestRecord({ exerciseId: exercise._id })
 
 const mocks = vi.hoisted(() => ({
   modifiers: [
@@ -23,6 +23,7 @@ const mocks = vi.hoisted(() => ({
     { name: 'heavy', weight: 25 },
   ],
   bodyweights: [] as Bodyweight[],
+  exercise: null as Exercise | null,
 }))
 
 const unofficialBw = createBodyweight(82.3, 'unofficial', '2000-01-01')
@@ -31,10 +32,12 @@ const officialBw = createBodyweight(76.4, 'official', '2000-01-01')
 vi.mock('./data/useQuery', () => ({
   useModifiers: () => mocks.modifiers,
   useBodyweights: () => ({ data: mocks.bodyweights }),
+  useExercise: () => mocks.exercise,
 }))
 
 beforeEach(() => {
   mocks.bodyweights = []
+  mocks.exercise = null
 })
 
 it('returns zero when nothing is using extra weight', () => {
@@ -56,15 +59,16 @@ it('returns extra weight when enabled', () => {
   const exerciseWeight = 7.5
   const bodyweight = 82.3
   mocks.bodyweights = [unofficialBw]
+  mocks.exercise = {
+    ...exercise,
+    weight: exerciseWeight,
+    attributes: { bodyweight: true },
+  }
+
   const { result } = renderHook(() =>
     useExtraWeight({
       ...record,
       activeModifiers: ['light', 'heavy'],
-      exercise: {
-        ...exercise,
-        weight: exerciseWeight,
-        attributes: { bodyweight: true },
-      },
     })
   )
 
@@ -91,11 +95,14 @@ it('handles unknown modifier', () => {
 })
 
 describe('bodyweight', () => {
+  beforeEach(() => {
+    mocks.exercise = bwExercise
+  })
+
   it('uses latest bw if latest two bws are different days', () => {
     // data is sorted newest first
     mocks.bodyweights = [{ ...officialBw, date: '2000-02-02' }, unofficialBw]
-
-    const { result } = renderHook(() => useExtraWeight(bwRecord))
+    const { result } = renderHook(() => useExtraWeight(record))
 
     expect(result.current).toMatchObject({
       bodyweight: officialBw.value,
@@ -106,7 +113,7 @@ describe('bodyweight', () => {
   it('uses unofficial weight if latest two bws are the same day', () => {
     // unofficial first
     mocks.bodyweights = [unofficialBw, officialBw]
-    const { result, rerender } = renderHook(() => useExtraWeight(bwRecord))
+    const { result, rerender } = renderHook(() => useExtraWeight(record))
 
     expect(result.current).toMatchObject({
       bodyweight: unofficialBw.value,
@@ -126,7 +133,7 @@ describe('bodyweight', () => {
   it('handles no bodyweight data', () => {
     mocks.bodyweights = []
 
-    const { result } = renderHook(() => useExtraWeight(bwRecord))
+    const { result } = renderHook(() => useExtraWeight(record))
 
     expect(result.current).toMatchObject({
       bodyweight: 0,

--- a/lib/frontend/useExtraWeight.ts
+++ b/lib/frontend/useExtraWeight.ts
@@ -1,20 +1,21 @@
 import type { Record } from '../../models/Record'
-import { useBodyweights, useModifiers } from './data/useQuery'
+import { useBodyweights, useExercise, useModifiers } from './data/useQuery'
 import { arrayToIndex } from './Index'
 
 export default function useExtraWeight(record: Record) {
   const modifiers = useModifiers()
   const modifierIndex = arrayToIndex('name', modifiers)
+  const exercise = useExercise(record.exerciseId)
   const { data: bodyweightData } = useBodyweights(
     {
       limit: 2,
       end: record.date,
       sort: 'newestFirst',
     },
-    record.exercise?.attributes.bodyweight
+    exercise?.attributes.bodyweight
   )
 
-  const { activeModifiers, exercise } = record
+  const { activeModifiers } = record
 
   let bodyweight = 0
   if (exercise?.attributes.bodyweight && bodyweightData?.length) {

--- a/lib/test/data.ts
+++ b/lib/test/data.ts
@@ -1,1 +1,11 @@
+import { createExercise } from '../../models/AsyncSelectorOption/Exercise'
+import { createRecord, type Record } from '../../models/Record'
+
 export const testDate = '2000-01-01'
+export const testExercise = createExercise('test exercise')
+
+export const createTestRecord = (data: Partial<Record> = {}) =>
+  createRecord(data.date ?? testDate, data.exerciseId ?? testExercise._id, {
+    sets: [],
+    ...data,
+  })

--- a/models/Record.test.ts
+++ b/models/Record.test.ts
@@ -12,15 +12,15 @@ it('transforms query params', () => {
     max: 8,
   }
   const recordQuery: RecordQuery = {
-    exercise: 'exercise',
+    exerciseId: 'ex1',
     modifiers: ['modifier'],
     modifierMatchType: ArrayMatchType.Exact,
     setType,
   }
 
   expect(buildRecordFilter(recordQuery)).toEqual({
+    exerciseId: 'ex1',
     activeModifiers: { $all: recordQuery.modifiers, $size: 1 },
-    'exercise.name': recordQuery.exercise,
     'setType.operator': setType.operator,
     'setType.field': setType.field,
     'setType.value': setType.value,
@@ -31,20 +31,20 @@ it('transforms query params', () => {
 
 it('ignores undefined keys', () => {
   const recordQuery: RecordQuery = {
-    exercise: '2000-01-01',
-    date: undefined,
+    date: '2000-01-01',
+    exerciseId: undefined,
   }
   expect(buildRecordFilter(recordQuery)).toEqual({
-    'exercise.name': recordQuery.exercise,
+    date: recordQuery.date,
   })
 })
 
 it('ignores setType when set to any', () => {
   const recordQuery: RecordQuery = {
-    exercise: '2000-01-01',
+    exerciseId: 'ex1',
     setTypeMatchType: ArrayMatchType.Any,
   }
   expect(buildRecordFilter(recordQuery)).toEqual({
-    'exercise.name': recordQuery.exercise,
+    exerciseId: recordQuery.exerciseId,
   })
 })

--- a/models/Record.ts
+++ b/models/Record.ts
@@ -3,7 +3,6 @@ import { DATE_FORMAT } from '../lib/frontend/constants'
 import { generateId } from '../lib/id'
 import { removeUndefinedKeys } from '../lib/util/object'
 import { ArrayMatchType, buildMatchTypeFilter } from './ArrayMatchType'
-import type { Exercise } from './AsyncSelectorOption/Exercise'
 import type FetchOptions from './FetchOptions'
 import type { Note } from './Note'
 import { DEFAULT_SET_TYPE, type Set, type SetType } from './Set'
@@ -11,10 +10,7 @@ import { DEFAULT_SET_TYPE, type Set, type SetType } from './Set'
 export interface Record {
   _id: string
   date: string
-  /** usually a record should always have an exercise, but in some cases the exercise can become null.
-   *  Eg, swapping category to a category not valid for the current exercise.
-   */
-  exercise?: Exercise | null
+  exerciseId: string
   activeModifiers: string[]
   notes: Note[]
   setType: SetType
@@ -23,8 +19,8 @@ export interface Record {
 
 export const createRecord = (
   date: string,
+  exerciseId: string,
   {
-    exercise = null,
     activeModifiers = [],
     notes = [],
     sets = [{}],
@@ -33,7 +29,7 @@ export const createRecord = (
 ): Record => ({
   _id: generateId(),
   date,
-  exercise,
+  exerciseId,
   activeModifiers,
   notes,
   sets,
@@ -41,7 +37,7 @@ export const createRecord = (
 })
 
 export interface RecordQuery extends FetchOptions {
-  exercise?: string
+  exerciseId?: string
   modifiers?: string[]
   modifierMatchType?: ArrayMatchType
   setType?: Partial<SetType>
@@ -50,7 +46,6 @@ export interface RecordQuery extends FetchOptions {
 }
 
 export const buildRecordFilter = ({
-  exercise,
   modifiers,
   modifierMatchType,
   setType: { field, operator, value, min, max } = {},
@@ -69,7 +64,6 @@ export const buildRecordFilter = ({
       : {}
 
   return removeUndefinedKeys({
-    'exercise.name': exercise,
     activeModifiers: buildMatchTypeFilter(modifiers, modifierMatchType),
     ...setTypeFields,
     ...rest,
@@ -77,7 +71,6 @@ export const buildRecordFilter = ({
 }
 
 export const DEFAULT_RECORD_HISTORY_QUERY: RecordQuery = {
-  exercise: '',
   modifiers: [],
   modifierMatchType: ArrayMatchType.Partial,
   setType: DEFAULT_SET_TYPE,

--- a/scripts/mongoSeedDev.ts
+++ b/scripts/mongoSeedDev.ts
@@ -145,8 +145,7 @@ const exercises = {
 }
 
 const records = [
-  createRecord('2022-09-20', {
-    exercise: exercises.squats,
+  createRecord('2022-09-20', exercises.squats._id, {
     activeModifiers: ['belt'],
     notes: [createNote('Very tired today', ['Session'])],
     setType: { operator: 'exactly', value: 6, field: 'reps' },
@@ -156,8 +155,7 @@ const records = [
       { reps: 6, effort: 9, weight: 100 },
     ],
   }),
-  createRecord('2022-09-22', {
-    exercise: exercises.squats,
+  createRecord('2022-09-22', exercises.squats._id, {
     activeModifiers: ['belt'],
     setType: { operator: 'exactly', value: 6, field: 'reps' },
     sets: [
@@ -166,8 +164,7 @@ const records = [
       { reps: 6, effort: 9, weight: 110 },
     ],
   }),
-  createRecord('2022-09-24', {
-    exercise: exercises.squats,
+  createRecord('2022-09-24', exercises.squats._id, {
     activeModifiers: ['belt'],
     setType: { operator: 'exactly', value: 6, field: 'reps' },
     sets: [
@@ -176,8 +173,7 @@ const records = [
       { reps: 6, effort: 10, weight: 110 },
     ],
   }),
-  createRecord('2022-09-26', {
-    exercise: exercises.squats,
+  createRecord('2022-09-26', exercises.squats._id, {
     activeModifiers: ['belt'],
     notes: [
       createNote('felt great', ['Set 1']),
@@ -190,8 +186,7 @@ const records = [
       { reps: 6, effort: 10, weight: 120 },
     ],
   }),
-  createRecord('2022-09-26', {
-    exercise: exercises.curls,
+  createRecord('2022-09-26', exercises.curls._id, {
     activeModifiers: [modifiers.dumbbell.name],
     notes: [createNote('felt great', ['Record'])],
     setType: { operator: 'between', min: 10, max: 15, field: 'reps' },
@@ -202,8 +197,7 @@ const records = [
       { reps: 10, weight: 30 },
     ],
   }),
-  createRecord('2022-09-26', {
-    exercise: exercises.sprints,
+  createRecord('2022-09-26', exercises.sprints._id, {
     setType: { operator: 'exactly', value: 50, field: 'distance' },
     sets: [
       { distance: 50, time: 10 },
@@ -211,18 +205,15 @@ const records = [
       { distance: 50, time: 8.33 },
     ],
   }),
-  createRecord('2022-09-26', {
-    exercise: exercises.running,
+  createRecord('2022-09-26', exercises.running._id, {
     setType: { operator: 'exactly', value: 5, field: 'distance' },
     sets: [{ distance: 5000, time: 900 }],
   }),
-  createRecord('2022-09-26', {
-    exercise: exercises.yoke,
+  createRecord('2022-09-26', exercises.yoke._id, {
     setType: { operator: 'exactly', value: 50, field: 'distance' },
     sets: [{ weight: 500, distance: 50, time: 8.5, effort: 9 }],
   }),
-  createRecord('2022-09-26', {
-    exercise: exercises.uprightRow,
+  createRecord('2022-09-26', exercises.uprightRow._id, {
     setType: { operator: 'at most', value: 20, field: 'reps' },
     sets: [
       { weight: 20, reps: 20 },
@@ -230,8 +221,7 @@ const records = [
       { weight: 20, reps: 17 },
     ],
   }),
-  createRecord('2022-09-26', {
-    exercise: exercises.chinUps,
+  createRecord('2022-09-26', exercises.chinUps._id, {
     setType: { operator: 'exactly', value: 6, field: 'reps' },
     sets: [
       { weight: 15, reps: 6 },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
       html: 'vitest/html/index.html',
     },
     environment: 'happy-dom',
+    testTimeout: 10_000,
     setupFiles: 'vitest.setup.ts',
     // clear mock history, restore each implementation to its original, and restore original descriptors of spied-on objects
     mockReset: true,


### PR DESCRIPTION
- Records have been storing the entire exercise object instead of just the exercise id. This is not useful since the exercise may update after fetch (eg, exercise notes) and then the record would not have up to date exercise data. Because of this the app has not even been using the exercise object stored in records. 
- Removes previous behavior of preserving (but hiding) active modifiers on records if the modifier is removed from the exercise. If a modifier is removed but that modifier is used on a previous record, the record is no longer affected. It will still use the old modifier, but that modifier will no longer be selectable for new records. This prevents records from being changed without warning. 
- removes helper text padding from autocompletes and fixes focus issue where clicking the space with the invisible helper text would open comboboxes.