### PR TITLE
fix interval timer not ticking after enabling react compiler

### DIFF
--- a/components/session/upper/RestTimer.tsx
+++ b/components/session/upper/RestTimer.tsx
@@ -55,6 +55,8 @@ interface IntervalTimer extends IntervalSettings {
 }
 
 export default function RestTimer() {
+  // memo breaks interval timer
+  'use no memo'
   const [state, dispatch] = useClockReducer()
   const { isRunning, displayValue, enabled, isFinished } = state
   const [intervalTimer, setIntervalTimer] = useState<

--- a/playwright/sessions.test.ts
+++ b/playwright/sessions.test.ts
@@ -53,3 +53,20 @@ test(`follows session redirect setting`, async ({ page }) => {
   // redirects
   await expect(page.getByText('Copy session')).toBeVisible()
 })
+
+test(`enables rest and interval timers`, async ({ page }) => {
+  await page.goto('/sessions')
+
+  await page.getByRole('button', { name: 'Start rest timer' }).click()
+  // rest timer ticks
+  await expect(page.getByText('00:00:01')).toBeVisible()
+
+  // start interval timer
+  await page.getByRole('button', { name: 'Start interval timer' }).click()
+  await page.getByRole('button', { name: 'Confirm' }).click()
+  await expect(page.getByText('Interval settings')).not.toBeVisible()
+
+  // interval timer ticks
+  await expect(page.getByText('Work')).toBeVisible()
+  await expect(page.getByText('Rest')).toBeVisible()
+})


### PR DESCRIPTION
the memoization had been preventing the component from updating the interval timer, so it was never ticking. 