### PR TITLE
Update navbar autohide to be more responsive

### DIFF
--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -12,15 +12,30 @@ import NavbarDrawer from './NavbarDrawer'
 
 export default function Navbar() {
   const [isVisible, setIsVisible] = useState(true)
+  const [lowPoint, setLowPoint] = useState(100)
+  const [highPoint, setHighPoint] = useState(0)
 
   // mui has a "useScrollTrigger" hook that it recommends using for this situation,
   // but it's very functionally limited and can't be modified much.
   useEffect(() => {
-    // This is a simple static Y value. May want to expand it such that
-    // when scrolling down y1 relative pixels it hides, and when scrolling up y2
-    // relative pixels it unhides.
     const handleScroll = () => {
-      setIsVisible(window.scrollY < 200)
+      const height = window.scrollY
+
+      if (isVisible) {
+        if (height - highPoint > 30) {
+          setIsVisible(false)
+          setLowPoint(height)
+        } else if (height < highPoint) {
+          setHighPoint(height)
+        }
+      } else {
+        if (lowPoint - height > 50) {
+          setIsVisible(true)
+          setHighPoint(height)
+        } else if (height > lowPoint) {
+          setLowPoint(height)
+        }
+      }
     }
 
     // adding "passive" is supposed to increase performance for scrolling. See:
@@ -30,7 +45,7 @@ export default function Navbar() {
     return () => {
       window.removeEventListener('scroll', handleScroll)
     }
-  }, [])
+  }, [lowPoint, highPoint, isVisible])
 
   return (
     <Slide appear={false} direction="down" in={isVisible}>

--- a/components/form-fields/NotesList/index.tsx
+++ b/components/form-fields/NotesList/index.tsx
@@ -53,7 +53,6 @@ export default memo(function NotesList({
   return (
     <>
       {label && <FormDivider title={label} />}
-      {/* todo: drag n drop? */}
       {!readOnly && (
         <AddNote
           placeholder={addItemPlaceholder}

--- a/models/DisplayFields.ts
+++ b/models/DisplayFields.ts
@@ -31,7 +31,6 @@ export interface DisplayFields {
   units: Units
 }
 
-// todo: dnd this? user pref? per exercise?
 export const ORDERED_DISPLAY_FIELDS: readonly VisibleField[] = [
   { name: 'side', source: 'side', enabled: { unilateral: true } },
   { name: 'weight', source: 'weight', enabled: { splitWeight: false } },


### PR DESCRIPTION
Navbar now responds to scrolling and hides depending on relative scroll instead of statically hiding after reaching a specific height